### PR TITLE
DATABASE_URL環境変数でDB接続を設定 (issue#14)

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,9 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=app_development
 
+# DATABASE_URL (Rails が自動的に使用)
+DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+
 # ==============================================
 # App name (編集可能)
 # Docker コンテナ名に使用されます


### PR DESCRIPTION
## 概要
DATABASE_URL環境変数を使用してデータベース接続を設定します。database.ymlの編集が不要になり、シンプルで保守しやすい実装になりました。

## 変更内容
- .envにDATABASE_URLを追加
- Railsが自動的にDATABASE_URLを優先して使用
- database.ymlの編集不要（Makefileのロジック不要）

## 実装詳細
```bash
# .env
DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
```

## メリット
- ✅ database.ymlを編集する必要がない
- ✅ Makefileがシンプルに保たれる
- ✅ Railsの標準的な方法
- ✅ 12 Factor Appの原則に準拠

## テスト結果
- ✅ データベース作成成功
- ✅ データベース接続成功（app_development）
- ✅ シンプルで保守しやすい

## チェックリスト
- [x] .envにDATABASE_URLを追加
- [x] データベース接続確認
- [x] 動作確認完了

## 関連issue
Closes #14