### PR TITLE
fix(makefile): make helpを定義順に表示 (issue#23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help
 help: ## ヘルプを表示
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: init
 init: ## Rails new を実行（初回のみ）


### PR DESCRIPTION
## 概要

make helpコマンドの出力を、アルファベット順ではなくMakefile内の定義順に表示するように修正しました。

## 変更内容

- Makefile:3行目から `| sort |` を削除
- これにより、make helpの出力がMakefile内の定義順に表示されるようになります

## テスト方法

```bash
# ヘルプを表示して順序を確認
make help

# 期待結果：help, init, up, bash, clean, prod-up... の順に表示される
```

## チェックリスト

- [x] テスト追加（不要：出力順序の変更のみ）
- [x] コーディング規約準拠
- [x] ドキュメント更新（不要：機能変更なし）

Closes #23