### PR TITLE
fix(init-ec): Sprockets構成に統一してassets.rbを追加 (issue#36)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,36 @@ init-ec: ## Solidus専用Railsアプリケーションを作成（ECサイト開
 	@echo "📦 Solidus専用Railsアプリケーションを作成します..."
 	@set -a && . ./.env.development && set +a && \
 	docker compose --env-file .env.development run --rm --workdir /app app \
-	rails new . --name $$APP_NAME --database=postgresql --javascript=importmap --force
+	rails new . --name $$APP_NAME --database=postgresql --javascript=importmap --skip-asset-pipeline --force
 	@echo "✅ Rails アプリケーションを作成しました"
+	@echo "🔧 アセットパイプラインをSprocketsに設定します..."
+	docker compose --env-file .env.development run --rm --workdir /app app bundle add sprockets-rails
+	@echo "✅ sprockets-railsを追加しました"
 	@echo "📄 Sprockets用のmanifest.jsを作成します..."
 	@mkdir -p app/assets/config
-	@printf "//= link_tree ../images\n//= link_directory ../stylesheets .css\n//= link_directory ../javascripts .js\n" > app/assets/config/manifest.js
+	@printf '%s\n' \
+		'//= link_tree ../images' \
+		'//= link_directory ../stylesheets .css' \
+		'//= link_directory ../javascripts .js' \
+		> app/assets/config/manifest.js
 	@echo "✅ manifest.jsを作成しました"
+	@echo "📄 assets initializerを作成します..."
+	@mkdir -p config/initializers
+	@printf '%s\n' \
+		'# Be sure to restart your server when you modify this file.' \
+		'' \
+		'# Version of your assets, change this if you want to expire all your assets.' \
+		'Rails.application.config.assets.version = "1.0"' \
+		'' \
+		'# Add additional assets to the asset load path.' \
+		'# Rails.application.config.assets.paths << Emoji.images_path' \
+		'' \
+		'# Precompile additional assets.' \
+		'# application.js, application.css, and all non-JS/CSS in the app/assets' \
+		'# folder are already added.' \
+		'# Rails.application.config.assets.precompile += %w( admin.js admin.css )' \
+		> config/initializers/assets.rb
+	@echo "✅ assets.rbを作成しました"
 	@echo "📦 mini_racerを追加します..."
 	docker compose --env-file .env.development run --rm --workdir /app app bundle add mini_racer
 	@echo "📦 Solidusをセットアップします..."

--- a/README.md
+++ b/README.md
@@ -128,12 +128,13 @@ make up
 ```
 
 **`make init-ec` で行われる処理:**
-- Rails newの実行（Solidus用に最適化）
-- Sprockets用のmanifest.js作成
-- `mini_racer`の追加
+- Rails newの実行（`--skip-asset-pipeline` で Propshaft を除外）
+- Sprockets有効化（`sprockets-rails` gemを追加）
+- Sprockets用の `manifest.js` と `assets.rb` を作成
+- `mini_racer`の追加（JavaScript実行エンジン）
 - Solidus gemの追加とインストール
-- データベースマイグレーション
-- サンプルデータのロード
+- データベースマイグレーションとサンプルデータのロード
+- Procfile.devの調整（Docker環境用に `-b 0.0.0.0` を追加）
 
 **重要:** `make init` と `make init-ec` は独立した処理です。どちらか一方のみを実行してください。
 


### PR DESCRIPTION
## 概要

`make init-ec` で生成される Solidus 構成を Sprockets に統一し、assets.rb の欠落による Solidus インストールエラーを修正しました。

## 変更内容

- Rails new に `--skip-asset-pipeline` フラグを追加（Propshaft を除外）
- sprockets-rails を明示的に追加
- manifest.js の生成を printf 形式に変更（可読性向上）
- assets.rb を新規作成（Solidus インストール前に必須）
- README.md の init-ec 処理内容を詳細化

## テスト方法

```bash
# 1. クリーンな状態から開始
make clean

# 2. Solidus 専用環境を作成
make init-ec

# 3. サーバー起動
make up

# 4. ブラウザで確認
# ストアフロント: http://localhost:3000
# 管理画面: http://localhost:3000/admin
# （ログイン: admin@example.com / test123）
```

### 検証結果

- ✅ Rails アプリケーション作成成功
- ✅ Sprockets が正常に動作
- ✅ Solidus インストール成功（assets.rb エラーなし）
- ✅ サーバー起動成功
- ✅ ストアフロント表示成功
- ✅ 管理画面アクセス成功
- ✅ アセット（CSS/JS）読み込み成功

## チェックリスト

- [x] テスト追加（手動検証完了）
- [x] コーディング規約準拠
- [x] ドキュメント更新

Closes #36