### PR TITLE
docs: README.mdの重複する貢献セクションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,8 +483,3 @@ docker compose --env-file .env.development exec app bash
 
 このプロジェクトはMITライセンスの下で公開されています。
 
----
-
-## 貢献
-
-貢献を歓迎します。Issue作成やPull Requestの詳細は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。


### PR DESCRIPTION
## 概要
README.mdの最下部にあった「## 貢献」セクションを削除しました。

## 変更内容
- 冒頭に「**貢献したい方は**: [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください」が既にあるため、最下部の重複セクションは不要と判断
- README.mdの488-490行目を削除

## 確認事項
- [x] 冒頭の貢献へのリンクは残っている
- [x] 重複が解消された