### PR TITLE
feat(init): make initにStripe gemと初期設定を追加 (issue#41)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -29,3 +29,11 @@ DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:$
 # Docker コンテナ名に使用されます
 # ==============================================
 APP_NAME=app
+
+# ==============================================
+# Stripe configuration (編集可能)
+# Stripe ダッシュボードから取得したキーを設定してください
+# https://dashboard.stripe.com/test/apikeys
+# ==============================================
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
+STRIPE_SECRET_KEY=sk_test_your_secret_key_here

--- a/.env.production
+++ b/.env.production
@@ -55,3 +55,11 @@ LANG=ja_JP.UTF-8
 # App name
 # ==============================================
 APP_NAME=app
+
+# ==============================================
+# Stripe configuration (本番環境用)
+# 本番環境ではライブキー (pk_live_..., sk_live_...) を使用してください
+# https://dashboard.stripe.com/apikeys
+# ==============================================
+STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key_here
+STRIPE_SECRET_KEY=sk_live_your_secret_key_here

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,24 @@ init: ## 定番gemを含むRailsアプリケーションを作成（通常開発
 	fi
 	@echo "📦 定番gemを追加します..."
 	docker compose --env-file .env.development run --rm --workdir /app app \
-	bash -c "bundle add mini_racer && \
+	bash -c "bundle add mini_racer stripe && \
 	bundle add pry-rails --group development && \
 	bundle add rspec-rails factory_bot_rails faker --group 'development,test'"
 	@echo "✅ 定番gemを追加しました"
+	@echo "📄 Stripe initializerを作成します..."
+	@mkdir -p config/initializers
+	@printf '%s\n' \
+		'# Stripe configuration' \
+		'# API keys are loaded from environment variables' \
+		'' \
+		'Rails.configuration.stripe = {' \
+		"  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY']," \
+		"  secret_key: ENV['STRIPE_SECRET_KEY']" \
+		'}' \
+		'' \
+		'Stripe.api_key = Rails.configuration.stripe[:secret_key]' \
+		> config/initializers/stripe.rb
+	@echo "✅ Stripe initializerを作成しました"
 	@echo "🎉 セットアップ完了！ 次のコマンド: make up"
 
 .PHONY: init-ec

--- a/README.md
+++ b/README.md
@@ -102,9 +102,15 @@ make up
 
 **`make init` で追加される定番gem:**
 - `mini_racer`: Node.js不要のV8エンジン
+- `stripe`: 決済処理
 - `pry-rails`: デバッグREPL（development）
 - `rspec-rails`, `factory_bot_rails`, `faker`: テスト関連（development, test）
 - Rails 8にはデフォルトで `rubocop-rails-omakase` が含まれます
+
+**Stripeの初期設定:**
+- `config/initializers/stripe.rb` が自動作成されます
+- `.env.development` にサンプルのAPIキーが含まれています
+- 実際に使用する場合は、[Stripe Dashboard](https://dashboard.stripe.com/test/apikeys) から取得したAPIキーに置き換えてください
 
 #### ECサイト開発（Solidus）の場合
 


### PR DESCRIPTION
## 概要
`make init` で自動的に Stripe gem がインストールされ、初期設定も完了するようにしました。

Closes #41

## 変更内容

### 1. Stripe gemの追加
- Makefile: `bundle add mini_racer stripe` として、mini_racerと一緒にstripeをインストール

### 2. 初期設定の自動化
- `config/initializers/stripe.rb` を自動作成
  - 環境変数からAPIキーを読み込む設定
  - `Stripe.api_key` の自動設定

### 3. 環境変数の追加
- `.env.development`: テストキー用のサンプルを追加
- `.env.production`: ライブキー用のサンプルを追加

### 4. ドキュメント更新
- README.md: 定番gemリストにstripeを追加
- README.md: Stripe初期設定の説明を追加

## 使い方

### 初回セットアップ後
`make init` を実行すると、以下が自動的に設定されます：
- Stripe gem のインストール
- `config/initializers/stripe.rb` の作成
- `.env.development` にサンプルキーが含まれている

### 実際にStripeを使う場合
1. [Stripe Dashboard](https://dashboard.stripe.com/test/apikeys) からAPIキーを取得
2. `.env.development` の以下の値を置き換え：
   ```
   STRIPE_PUBLISHABLE_KEY=pk_test_あなたのキー
   STRIPE_SECRET_KEY=sk_test_あなたのキー
   ```
3. アプリケーションを再起動（`make up`）

## 確認事項
- [x] Makefileでstripeがmini_racerと一緒にインストールされる
- [x] `config/initializers/stripe.rb` が自動作成される
- [x] `.env.development` にStripe環境変数が追加されている
- [x] `.env.production` にStripe環境変数が追加されている
- [x] README.mdの定番gemリストにstripeが追加された
- [x] README.mdにStripe初期設定の説明が追加された
- [x] make init-ecには影響しない（変更なし）

## 生成されるinitializer

```ruby
# Stripe configuration
# API keys are loaded from environment variables

Rails.configuration.stripe = {
  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
  secret_key: ENV['STRIPE_SECRET_KEY']
}

Stripe.api_key = Rails.configuration.stripe[:secret_key]
```