### PR TITLE
docs: CONTRIBUTINGとCLAUDEに実践的なガイドラインを追加 (issue#47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,50 @@ Add a user model
 
 ---
 
+## 自動実行ポリシー
+
+Claude Code が操作を実行する際の基準を定義します。
+
+### 確認なしで実行可能
+
+以下の**読み取り専用操作**は、確認なしで自動実行できます：
+
+- **ファイル読み取り**: Read, Grep, Glob
+- **状態確認コマンド**:
+  - `git status`, `git log`, `git diff`
+  - `docker ps`, `docker compose ps`
+  - `ls`, `cat`, `grep`, `find`
+- **ログ確認**:
+  - `docker compose logs`
+  - `make logs`
+- **テスト実行**:
+  - `bundle exec rspec`
+
+### 必ず確認が必要
+
+以下の**書き込み・変更操作**は、ユーザーの明示的な承認が必要です：
+
+- **データベース操作**:
+  - `bin/rails db:create`, `db:migrate`, `db:seed`
+  - `bin/rails db:drop`, `db:reset`
+  - SQL の INSERT/UPDATE/DELETE
+- **Git 操作**:
+  - `git commit`, `git push`
+  - `git branch` 作成・削除
+  - `git merge`, `git rebase`
+- **ファイル削除・上書き**:
+  - Write, Edit（既存ファイルの上書き）
+  - `rm`, `mv`（ファイル削除・移動）
+  - `docker compose down -v`（ボリューム削除）
+- **本番環境への操作**:
+  - デプロイコマンド
+  - 環境変数の変更
+  - 本番データベースへのアクセス
+
+**原則**: データの永続的な変更や、元に戻せない操作は必ず確認する。
+
+---
+
 ## 参考リンク
 
 - [README.md](README.md) - プロジェクト固有の技術情報

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -583,34 +583,141 @@ Squash and merge ▼
 
 ### Rails
 
-- ビジネスロジックは Service Object に抽出する
-- 変更が広がる場合は Decorator / Concern を検討する
-- RuboCop などの静的解析がある場合は準拠する
+#### 1. Service Object パターン
 
-### Ruby
+複雑なビジネスロジックは Service Object に抽出：
 
-- 1メソッド1責務を意識
-- 早期 return でネストを浅く
+```ruby
+# app/services/order_service.rb
+class OrderService
+  def initialize(order:)
+    @order = order
+  end
+
+  def call
+    # ビジネスロジック
+  end
+end
+```
+
+#### 2. 早期リターン
+
+条件分岐はネストを避け、早期リターンを使用：
+
+```ruby
+# ✅ GOOD: 早期リターン
+def process(order)
+  return if order.nil?
+  return unless order.valid?
+
+  order.save
+end
+
+# ❌ BAD: ネストが深い
+def process(order)
+  if order.present?
+    if order.valid?
+      order.save
+    end
+  end
+end
+```
+
+#### 3. RuboCop 準拠
+
+```bash
+# チェック
+bundle exec rubocop
+
+# 自動修正
+bundle exec rubocop -a
+```
+
+### データベース
+
+#### 1. マイグレーション命名規則
+
+```ruby
+# タイムスタンプ_動詞_対象_詳細.rb
+20251206_add_phone_number_to_users.rb
+20251206_create_orders.rb
+20251206_add_index_to_products_category_id.rb
+```
+
+#### 2. ロールバック可能性
+
+すべてのマイグレーションは `down` メソッドを実装：
+
+```ruby
+class AddPhoneNumberToUsers < ActiveRecord::Migration[8.0]
+  def up
+    add_column :users, :phone_number, :string
+  end
+
+  def down
+    remove_column :users, :phone_number
+  end
+end
+```
+
+#### 3. カラムコメント必須
+
+```ruby
+add_column :products, :category, :string, comment: "商品カテゴリ"
+add_column :products, :price, :decimal, comment: "価格（税抜）"
+```
 
 ---
 
 ## テスト方針
 
-- 新機能・修正にはテストを追加する
-- RSpec を標準テストフレームワークとして扱う
+### RSpec 必須
 
-例:
+すべての新機能・修正にはテストを追加してください。
+
+#### モデルテスト
 
 ```ruby
-# spec/models/user_spec.rb
+# spec/models/product_spec.rb
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
-  it 'is valid with a name' do
-    user = build(:user, name: 'Alice')
-    expect(user).to be_valid
+RSpec.describe Product, type: :model do
+  describe '#active?' do
+    it 'ステータスがactiveの場合trueを返す' do
+      product = build(:product, status: 'active')
+      expect(product.active?).to be true
+    end
   end
 end
+```
+
+#### API テスト（Request Spec）
+
+```ruby
+# spec/requests/api/v1/orders_spec.rb
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Orders', type: :request do
+  describe 'GET /api/v1/orders' do
+    it '注文一覧を返す' do
+      get '/api/v1/orders'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end
+```
+
+### テスト実行
+
+```bash
+# 全テスト実行
+bundle exec rspec
+
+# 特定ファイルのみ
+bundle exec rspec spec/models/product_spec.rb
+
+# カバレッジ確認
+bundle exec rspec --format documentation
 ```
 
 ---
@@ -733,6 +840,32 @@ def update
   @post = Post.find(params[:id])  # ❌
   @post.update(post_params)
 end
+```
+
+### パフォーマンスチェック
+
+#### 1. N+1 クエリ回避
+
+**✅ DO: eager loading 使用**
+```ruby
+# 良い例
+@products = Product.includes(:images, :variants).all
+```
+
+**❌ DON'T: N+1発生**
+```ruby
+# 悪い例
+@products = Product.all
+@products.each { |p| p.images.first }  # N+1！
+```
+
+#### 2. インデックス追加
+
+頻繁に検索するカラムにはインデックス：
+
+```ruby
+add_index :products, :category_id
+add_index :orders, [:user_id, :created_at]
 ```
 
 ---


### PR DESCRIPTION
## 概要

landbase_ai_suiteのCONTRIBUTING.mdとCLAUDE.mdを参考に、rails_boilerplateのドキュメントに不足していた実用的なガイドラインと具体例を追加しました。

## 変更内容

### CONTRIBUTING.md
- **コーディング規約の拡充**
  - Service Objectパターンの実例
  - 早期リターンの良い例と悪い例
  - RuboCop準拠の手順
- **データベース規約の追加**
  - マイグレーション命名規則
  - ロールバック可能性（up/downメソッド）
  - カラムコメント必須化
- **テスト方針の拡充**
  - RSpecモデルテストの実例
  - RSpec APIテスト（Request Spec）の実例
  - テスト実行コマンド
- **パフォーマンスチェックセクションの追加**
  - N+1クエリ回避（eager loading）
  - インデックス追加の推奨

### CLAUDE.md
- **自動実行ポリシーセクションの追加**
  - 確認なしで実行可能な操作（読み取り専用）
  - 確認が必要な操作（書き込み・変更）
  - 操作の判断基準を明確化

## テスト方法

ドキュメントの変更のため、コードの動作確認は不要です。
以下のファイルを確認してください：

```bash
# CONTRIBUTING.mdの変更内容を確認
cat CONTRIBUTING.md

# CLAUDE.mdの変更内容を確認
cat CLAUDE.md
```

## チェックリスト

- [x] CONTRIBUTING.mdにコーディング規約の具体例を追加
- [x] CONTRIBUTING.mdにデータベース規約を追加
- [x] CONTRIBUTING.mdにテスト方針の実例を追加
- [x] CONTRIBUTING.mdにパフォーマンスチェックセクションを追加
- [x] CLAUDE.mdに自動実行ポリシーセクションを追加
- [x] ドキュメント間の整合性を確認

Closes #47