### PR TITLE
fix(init): make init時にREADME.mdが上書きされる問題を修正 (issue#49)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ help: ## ヘルプを表示
 .PHONY: init
 init: ## 定番gemを含むRailsアプリケーションを作成（通常開発用）
 	@echo "📦 Railsアプリケーションを作成します..."
+	@[ -f README.md ] && cp README.md README.md.bak || true
 	@set -a && . ./.env.development && set +a && \
 	docker compose --env-file .env.development run --rm --workdir /app app \
 	rails new . --name $$APP_NAME --database=postgresql --css=tailwind --javascript=importmap --skip-test --force
+	@[ -f README.md.bak ] && mv README.md.bak README.md || true
 	@echo "✅ Rails アプリケーションを作成しました"
 	@echo "⚙️  Procfile.devをDocker環境用に調整します..."
 	@if [ -f Procfile.dev ]; then \
@@ -41,9 +43,11 @@ init: ## 定番gemを含むRailsアプリケーションを作成（通常開発
 .PHONY: init-ec
 init-ec: ## Solidus専用Railsアプリケーションを作成（ECサイト開発用）
 	@echo "📦 Solidus専用Railsアプリケーションを作成します..."
+	@[ -f README.md ] && cp README.md README.md.bak || true
 	@set -a && . ./.env.development && set +a && \
 	docker compose --env-file .env.development run --rm --workdir /app app \
 	rails new . --name $$APP_NAME --database=postgresql --javascript=importmap --skip-asset-pipeline --force
+	@[ -f README.md.bak ] && mv README.md.bak README.md || true
 	@echo "✅ Rails アプリケーションを作成しました"
 	@echo "🔧 アセットパイプラインをSprocketsに設定します..."
 	docker compose --env-file .env.development run --rm --workdir /app app bundle add sprockets-rails


### PR DESCRIPTION
## 概要

`make init` / `make init-ec` で `rails new . --force` 実行時にREADME.mdがRailsデフォルトのREADMEで上書きされる問題を修正。

## 変更内容

- `init` ターゲット: `rails new` の前後にREADME.mdのバックアップ・リストアを追加
- `init-ec` ターゲット: 同上

## テスト方法

```bash
# Makefileの変更内容を目視確認
make help
```

## チェックリスト

- [x] コーディング規約準拠
- [x] ドキュメント更新（不要）

Closes #49