### PR TITLE
feat(init): make initに定番gemを追加し、Deviseを手動セットアップに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ init: ## 定番gemを含むRailsアプリケーションを作成（通常開発
 	fi
 	@echo "📦 定番gemを追加します..."
 	docker compose --env-file .env.development run --rm --workdir /app app \
-	bash -c "bundle add mini_racer stripe && \
+	bash -c "bundle add mini_racer stripe devise kaminari rack-cors && \
 	bundle add pry-rails --group development && \
 	bundle add rspec-rails factory_bot_rails faker --group 'development,test'"
 	@echo "✅ 定番gemを追加しました"
@@ -38,6 +38,22 @@ init: ## 定番gemを含むRailsアプリケーションを作成（通常開発
 		'Stripe.api_key = Rails.configuration.stripe[:secret_key]' \
 		> config/initializers/stripe.rb
 	@echo "✅ Stripe initializerを作成しました"
+	@echo "📄 CORS initializerを作成します..."
+	@printf '%s\n' \
+		'# CORS configuration' \
+		'# Adjust origins for your production environment' \
+		'' \
+		'Rails.application.config.middleware.insert_before 0, Rack::Cors do' \
+		'  allow do' \
+		'    origins "http://localhost:3000"' \
+		'' \
+		'    resource "*",' \
+		'      headers: :any,' \
+		'      methods: [:get, :post, :put, :patch, :delete, :options, :head]' \
+		'  end' \
+		'end' \
+		> config/initializers/cors.rb
+	@echo "✅ CORS initializerを作成しました"
 	@echo "🎉 セットアップ完了！ 次のコマンド: make up"
 
 .PHONY: init-ec

--- a/README.md
+++ b/README.md
@@ -103,9 +103,33 @@ make up
 **`make init` で追加される定番gem:**
 - `mini_racer`: Node.js不要のV8エンジン
 - `stripe`: 決済処理
+- `devise`: 認証（要手動セットアップ）
+- `kaminari`: ページネーション
+- `rack-cors`: CORS対応
 - `pry-rails`: デバッグREPL（development）
 - `rspec-rails`, `factory_bot_rails`, `faker`: テスト関連（development, test）
 - Rails 8にはデフォルトで `rubocop-rails-omakase` が含まれます
+
+**自動生成されるinitializer:**
+- `config/initializers/stripe.rb`: Stripe APIキー設定
+- `config/initializers/cors.rb`: CORS設定（開発環境向けデフォルト）
+
+**Deviseの手動セットアップ:**
+
+Devise gemはインストール済みですが、使用する場合は以下の手順でセットアップしてください：
+
+```bash
+# コンテナ内で実行
+rails generate devise:install
+rails generate devise User
+rails db:migrate
+```
+
+セットアップ後、以下の設定を追加してください：
+- ルートパス (`config/routes.rb`)
+- フラッシュメッセージ (`app/views/layouts/application.html.erb`)
+
+詳細は `rails generate devise:install` 実行時に表示される指示を参照してください。
 
 **Stripeの初期設定:**
 - `config/initializers/stripe.rb` が自動作成されます


### PR DESCRIPTION
## 概要

`make init` に以下の定番gemを追加し、Deviseのセットアップ方針を変更しました。

### 変更内容

- **追加した定番gem:**
  - `devise`: 認証機能
  - `kaminari`: ページネーション
  - `rack-cors`: CORS対応

- **CORS initializer の自動生成:**
  - `config/initializers/cors.rb` を自動作成
  - 開発環境向けのデフォルト設定を提供

- **Deviseのセットアップ方針変更:**
  - `rails generate devise:install` の自動実行を削除
  - gemのインストールのみに変更（手動セットアップが必要）
  - README.mdに手動セットアップ手順を追加

### 変更理由

Deviseを `make init` で自動セットアップすると、以下の設定が不完全な状態になります：
- ルートパスの設定
- フラッシュメッセージの追加
- User モデルの生成

これらは各プロジェクトの要件に応じて設定すべきであり、ボイラープレートで自動化すべきではないと判断しました。

## テスト計画

- [x] `make init` が正常に完了することを確認
- [x] 追加したgemがGemfileに含まれることを確認
- [x] CORS initializerが正しく生成されることを確認
- [x] Deviseの自動セットアップが実行されないことを確認
- [x] README.mdにDeviseの手動セットアップ手順が記載されていることを確認

Closes #51