### PR TITLE
fix(env): .env.productionから不要なAPP_NAME変数を削除 (issue#56)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -58,11 +58,6 @@ LANG=ja_JP.UTF-8
 DOMAIN=yourdomain.com
 
 # ==============================================
-# App name
-# ==============================================
-APP_NAME=app
-
-# ==============================================
 # Stripe configuration (本番環境用)
 # 本番環境ではライブキー (pk_live_..., sk_live_...) を使用してください
 # https://dashboard.stripe.com/apikeys


### PR DESCRIPTION
## 📋 概要

`.env.production` から本番環境で使用されない `APP_NAME` 変数を削除。

Closes #56

## 🔄 変更内容

- `.env.production` から `APP_NAME=app` とそのセクションコメントを削除（5行削除）

## 🎯 背景

`APP_NAME` は `Makefile` の `rails new --name $$APP_NAME` でのみ使用され、`make init` / `make init-ec` 時（開発環境セットアップ）にしか参照されない。`.env.development` には引き続き残しており、開発フローへの影響はない。

## ✅ 確認事項

- [x] `.env.production` から APP_NAME 関連の記述が削除されている
- [x] `.env.development` の APP_NAME は維持されている