### PR TITLE
refactor(make): 本番環境コマンドをprod-deployに統合 (issue#58)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,20 +135,13 @@ clean: ## このプロジェクトのDocker関連をクリーン（公式イメ�
 # 本番環境用コマンド
 # ==============================================
 
-.PHONY: prod-up
-prod-up: ## 本番環境を起動
-	docker compose -f compose.production.yaml --env-file .env.production up -d
-	@echo "✅ 本番環境が起動しました"
-
-.PHONY: prod-down
-prod-down: ## 本番環境を停止
-	docker compose -f compose.production.yaml --env-file .env.production down
-	@echo "✅ 本番環境を停止しました"
-
-.PHONY: prod-build
-prod-build: ## 本番環境のイメージをビルド
+.PHONY: prod-deploy
+prod-deploy: ## 本番環境をデプロイ（ビルド→再作成→マイグレーション→シード）
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
-	@echo "✅ 本番環境のイメージをビルドしました"
+	docker compose -f compose.production.yaml --env-file .env.production down
+	docker compose -f compose.production.yaml --env-file .env.production up -d
+	docker compose -f compose.production.yaml --env-file .env.production exec app rails db:create db:migrate db:seed
+	@echo "✅ デプロイが完了しました"
 
 .PHONY: prod-logs
 prod-logs: ## 本番環境のログを表示
@@ -158,21 +151,11 @@ prod-logs: ## 本番環境のログを表示
 prod-bash: ## 本番環境のappコンテナに入る
 	docker compose -f compose.production.yaml --env-file .env.production exec app bash
 
-.PHONY: prod-db-setup
-prod-db-setup: ## 本番環境のデータベースをセットアップ
-	docker compose -f compose.production.yaml --env-file .env.production exec app rails db:create db:migrate
-	@echo "✅ データベースをセットアップしました"
-
 .PHONY: prod-db-reset
 prod-db-reset: ## 本番環境のデータベースをリセット（注意：全データ削除）
 	@echo "⚠️  警告: 全てのデータが削除されます。続行しますか? [y/N]" && read ans && [ $${ans:-N} = y ]
 	docker compose -f compose.production.yaml --env-file .env.production exec app rails db:reset
 	@echo "✅ データベースをリセットしました"
-
-.PHONY: prod-restart
-prod-restart: ## 本番環境を再起動
-	docker compose -f compose.production.yaml --env-file .env.production restart
-	@echo "✅ 本番環境を再起動しました"
 
 .PHONY: prod-ps
 prod-ps: ## 本番環境のコンテナ状態を表示

--- a/README.md
+++ b/README.md
@@ -336,11 +336,8 @@ make clean
 ### 本番環境
 
 ```bash
-# 本番環境を起動
-make prod-up
-
-# 本番環境を停止
-make prod-down
+# 本番環境をデプロイ（ビルド→再作成→マイグレーション→シード）
+make prod-deploy
 
 # 本番環境のログを表示
 make prod-logs
@@ -350,15 +347,6 @@ make prod-bash
 
 # 本番環境のコンテナ状態を表示
 make prod-ps
-
-# イメージをビルド
-make prod-build
-
-# 本番環境を再起動
-make prod-restart
-
-# データベースをセットアップ
-make prod-db-setup
 
 # その他の本番環境コマンド
 make help  # 全コマンド確認
@@ -414,18 +402,17 @@ vi .env.production
 - `POSTGRES_PASSWORD`: ランダムな強力なパスワードに変更
 - `DOMAIN`: 本番環境のドメイン名（例: `example.com`）
 
-#### 2. 本番環境の起動
+#### 2. デプロイ
 
 ```bash
-# イメージをビルド
-make prod-build
-
-# 本番環境を起動
-make prod-up
-
-# データベースをセットアップ
-make prod-db-setup
+make prod-deploy
 ```
+
+このコマンドで以下が一括実行されます:
+1. イメージをビルド（`--no-cache`）
+2. 既存コンテナを停止
+3. コンテナを起動
+4. データベースのセットアップ（`db:create db:migrate db:seed`）
 
 #### 3. 確認
 
@@ -441,11 +428,8 @@ Caddy が自動的に Let's Encrypt から SSL 証明書を取得します。初
 # VPS上で
 git pull origin main
 
-# イメージを再ビルド
-make prod-build
-
-# 本番環境を再起動
-make prod-restart
+# デプロイ
+make prod-deploy
 ```
 
 ---
@@ -520,10 +504,8 @@ make prod-logs
 # コンテナ状態を確認
 make prod-ps
 
-# クリーンアップして再起動
-make prod-down
-make prod-build
-make prod-up
+# クリーンアップして再デプロイ
+make prod-deploy
 ```
 
 #### データベース接続エラー
@@ -532,9 +514,8 @@ make prod-up
 # データベースコンテナの状態を確認
 make prod-ps
 
-# データベースを再セットアップ（注意: 全データ削除）
+# データベースをリセット（注意: 全データ削除）
 make prod-db-reset
-make prod-db-setup
 ```
 
 ### よくある質問


### PR DESCRIPTION
## 概要

本番環境の個別Makeターゲットを `prod-deploy` に統合し、norn_os プロジェクトと同じ運用フローに統一する。

## 変更内容

- `prod-deploy` ターゲットを追加（ビルド→停止→起動→DBセットアップを一括実行）
- 不要な個別ターゲットを削除（`prod-up`, `prod-down`, `prod-build`, `prod-db-setup`, `prod-restart`）
- `prod-logs`, `prod-bash`, `prod-db-reset`, `prod-ps` は維持
- README.md の本番環境コマンド・デプロイ手順・トラブルシューティングを更新

## テスト方法

```bash
make help  # prod-deploy が表示されることを確認
```

## チェックリスト

- [ ] コーディング規約準拠
- [x] ドキュメント更新

Closes #58