### PR TITLE
refactor(docker): 開発コンテナの起動コマンドをbin/setupとbin/devに整理 (issue#67)

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -23,7 +23,7 @@ services:
       args:
         RUBY_VERSION: ${RUBY_VERSION}
         RAILS_VERSION: ${RAILS_VERSION}
-    command: bash -c "rm -f tmp/pids/server.pid && bin/dev"
+    command: bash -c "bin/setup && bin/dev"
     volumes:
       - .:/app
       - bundle_cache:/usr/local/bundle


### PR DESCRIPTION
## 概要

`compose.development.yaml` の `command` を Rails 8 の規約に沿った `bin/setup && bin/dev` に変更。

## 変更内容

- `command: bash -c "rm -f tmp/pids/server.pid && bin/dev"` → `command: bash -c "bin/setup && bin/dev"`

## 背景

`bin/setup` は Rails 8 が自動生成するセットアップスクリプトで、以下をまとめて実行する：
- `bundle install`（Gem追加時に再ビルド不要）
- `rails db:prepare`（DB作成・マイグレーション）
- `rails tmp:clear`（PIDファイル削除含む）

これにより `make up` だけで開発を再開できるようになる。

## テスト方法

```bash
make init  # 初回のみ
make up    # bin/setup → bin/dev が順に実行されること
```

## チェックリスト

- [x] compose.development.yaml の command が更新されている

Closes #67