### PR TITLE
refactor: 不要な環境変数と設定記述を整理 (issue#69)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -25,12 +25,6 @@ POSTGRES_DB=app_development
 DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # ==============================================
-# App name (編集可能)
-# Docker コンテナ名に使用されます
-# ==============================================
-APP_NAME=app
-
-# ==============================================
 # Stripe configuration (編集可能)
 # Stripe ダッシュボードから取得したキーを設定してください
 # https://dashboard.stripe.com/test/apikeys

--- a/.env.production
+++ b/.env.production
@@ -52,11 +52,6 @@ PORT=3000
 LANG=ja_JP.UTF-8
 
 # ==============================================
-# Domain configuration
-# ドメイン名は reverse-proxy/Caddyfile に直接記載してください
-# ==============================================
-
-# ==============================================
 # Stripe configuration (本番環境用)
 # 本番環境ではライブキー (pk_live_..., sk_live_...) を使用してください
 # https://dashboard.stripe.com/apikeys

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ help: ## ヘルプを表示
 init: ## 定番gemを含むRailsアプリケーションを作成（通常開発用）
 	@echo "📦 Railsアプリケーションを作成します..."
 	@[ -f README.md ] && cp README.md README.md.bak || true
-	@set -a && . ./.env.development && set +a && \
 	docker compose -f compose.development.yaml --env-file .env.development run --rm --workdir /app app \
-	rails new . --name $$APP_NAME --database=postgresql --css=tailwind --javascript=importmap --skip-test --force
+	rails new . --name railsapp --database=postgresql --css=tailwind --javascript=importmap --skip-test --force
 	@[ -f README.md.bak ] && mv README.md.bak README.md || true
 	@echo "✅ Rails アプリケーションを作成しました"
 	@echo "⚙️  Procfile.devをDocker環境用に調整します..."
@@ -60,9 +59,8 @@ init: ## 定番gemを含むRailsアプリケーションを作成（通常開発
 init-ec: ## Solidus専用Railsアプリケーションを作成（ECサイト開発用）
 	@echo "📦 Solidus専用Railsアプリケーションを作成します..."
 	@[ -f README.md ] && cp README.md README.md.bak || true
-	@set -a && . ./.env.development && set +a && \
 	docker compose -f compose.development.yaml --env-file .env.development run --rm --workdir /app app \
-	rails new . --name $$APP_NAME --database=postgresql --javascript=importmap --skip-asset-pipeline --force
+	rails new . --name railsapp --database=postgresql --javascript=importmap --skip-asset-pipeline --force
 	@[ -f README.md.bak ] && mv README.md.bak README.md || true
 	@echo "✅ Rails アプリケーションを作成しました"
 	@echo "🔧 アセットパイプラインをSprocketsに設定します..."

--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ Internet
 
 #### 設計方針
 
-- `.env` ファイルは使用しない
 - `--env-file` オプションで環境ファイルを明示的に指定
 - 開発環境: `docker compose -f compose.development.yaml --env-file .env.development`
 - 本番環境: `docker compose -f compose.production.yaml --env-file .env.production`
@@ -273,14 +272,12 @@ Internet
 - `RUBY_VERSION`: Ruby version (default: 3.3.6)
 - `RAILS_VERSION`: Rails version (default: 8.0.4)
 - `POSTGRES_VERSION`: PostgreSQL version (default: 16-bookworm)
-- `APP_NAME`: Application name
 - `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`: Database credentials
 - `DATABASE_URL`: PostgreSQL connection URL (auto-generated)
 
 **本番環境用追加環境変数（.env.production）:**
 - `SECRET_KEY_BASE`: Rails secret key（**必ず変更**）
 - `POSTGRES_PASSWORD`: データベースパスワード（**必ず変更**）
-- `DOMAIN`: 本番環境のドメイン名（**必ず変更**、例: `example.com`）
 - `RAILS_ENV=production`
 - `RAILS_LOG_TO_STDOUT=true`
 - `RAILS_SERVE_STATIC_FILES=true`


### PR DESCRIPTION
## 📋 概要

closes #69

不要になった環境変数（`APP_NAME`、`DOMAIN`）と誤った設計方針の記述を削除。

## 変更内容

- `.env.development`: `APP_NAME=app` とコメントブロックを削除
- `.env.production`: Domain configuration のコメントブロックを削除
- `Makefile`: `--name $$APP_NAME` → `--name railsapp` に固定化、不要な `set -a` を削除
- `README.md`: `APP_NAME`、`DOMAIN`、「`.env` ファイルは使用しない」の記述を削除

## 受け入れ基準

- [x] `.env.development` に `APP_NAME` が存在しない
- [x] `Makefile` で `--name railsapp` が使用されている
- [x] `.env.production` に Domain configuration コメントが存在しない
- [x] README.md から不要な記述が削除されている