### PR TITLE
refactor(docker): reverse-proxy/にMakefileを追加し、ディレクトリを自己完結化 (issue#73)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,36 +130,11 @@ clean: ## このプロジェクトのDocker関連をクリーン（公式イメ�
 	docker compose -f compose.development.yaml --env-file .env.development down -v --rmi local
 
 # ==============================================
-# リバースプロキシ用コマンド
-# ==============================================
-
-.PHONY: proxy-up
-proxy-up: ## リバースプロキシを起動
-	docker network inspect web-proxy-net >/dev/null 2>&1 || docker network create web-proxy-net
-	docker compose -f reverse-proxy/compose.yaml up -d
-	@echo "✅ リバースプロキシを起動しました"
-
-.PHONY: proxy-down
-proxy-down: ## リバースプロキシを停止
-	docker compose -f reverse-proxy/compose.yaml down
-	@echo "✅ リバースプロキシを停止しました"
-
-.PHONY: proxy-logs
-proxy-logs: ## リバースプロキシのログを表示
-	docker compose -f reverse-proxy/compose.yaml logs -f
-
-.PHONY: proxy-reload
-proxy-reload: ## リバースプロキシの設定を再読み込み
-	docker compose -f reverse-proxy/compose.yaml exec caddy caddy reload --config /etc/caddy/Caddyfile
-	@echo "✅ Caddyfile を再読み込みしました"
-
-# ==============================================
 # 本番環境用コマンド
 # ==============================================
 
 .PHONY: prod-deploy
 prod-deploy: ## 本番環境をデプロイ（ビルド→再作成→マイグレーション→シード）
-	docker network inspect web-proxy-net >/dev/null 2>&1 || docker network create web-proxy-net
 	docker compose -f compose.production.yaml --env-file .env.production build --no-cache
 	docker compose -f compose.production.yaml --env-file .env.production down
 	docker compose -f compose.production.yaml --env-file .env.production up -d

--- a/README.md
+++ b/README.md
@@ -342,18 +342,25 @@ make clean
 
 ### リバースプロキシ
 
+`reverse-proxy/` ディレクトリは自己完結しています。ディレクトリに移動して操作してください。
+
 ```bash
+cd reverse-proxy/
+
 # リバースプロキシを起動（web-proxy-netも自動作成）
-make proxy-up
+make up
 
 # リバースプロキシを停止
-make proxy-down
+make down
 
 # リバースプロキシのログを表示
-make proxy-logs
+make logs
 
 # Caddyfile変更後に設定を再読み込み
-make proxy-reload
+make reload
+
+# コマンド一覧
+make help
 ```
 
 ### 本番環境
@@ -428,11 +435,15 @@ vi .env.production
 #### 2. リバースプロキシの設定・起動
 
 ```bash
+cd reverse-proxy/
+
 # Caddyfileにドメイン名を設定
-vi reverse-proxy/Caddyfile
+vi Caddyfile
 
 # リバースプロキシを起動（web-proxy-netネットワークも自動作成）
-make proxy-up
+make up
+
+cd ..
 ```
 
 #### 3. アプリケーションのデプロイ
@@ -474,9 +485,10 @@ make prod-deploy
 .
 ├── .env.development          # 開発環境用環境変数（コミット済み）
 ├── .env.production           # 本番環境用環境変数テンプレート（コミット済み）
-├── reverse-proxy/            # リバースプロキシ（独立管理）
+├── reverse-proxy/            # リバースプロキシ（独立管理、ディレクトリごとコピーで運用可能）
 │   ├── compose.yaml          # Caddy用 Docker Compose 設定
-│   └── Caddyfile             # Caddy リバースプロキシ設定
+│   ├── Caddyfile             # Caddy リバースプロキシ設定
+│   └── Makefile              # リバースプロキシ操作コマンド
 ├── compose.development.yaml  # 開発環境用 Docker Compose 設定
 ├── compose.production.yaml   # 本番環境用 Docker Compose 設定（app + db）
 ├── Dockerfile.app            # Appコンテナ定義（マルチステージビルド）

--- a/docs/vps-setup.md
+++ b/docs/vps-setup.md
@@ -69,11 +69,10 @@ chown -R devuser:devuser /srv
 mkdir -p /srv/reverse-proxy
 ```
 
-本リポジトリの `reverse-proxy/` 内のファイルを配置します。
+本リポジトリの `reverse-proxy/` ディレクトリごとコピーします。
 
 ```bash
-scp reverse-proxy/compose.yaml devuser@<VPS_IP>:/srv/reverse-proxy/
-scp reverse-proxy/Caddyfile devuser@<VPS_IP>:/srv/reverse-proxy/
+scp -r reverse-proxy/ devuser@<VPS_IP>:/srv/reverse-proxy/
 ```
 
 **Caddyfile のドメイン設定:**
@@ -93,8 +92,8 @@ example.com {
 **起動:**
 
 ```bash
-docker network create web-proxy-net
-docker compose -f /srv/reverse-proxy/compose.yaml up -d
+cd /srv/reverse-proxy/
+make up
 ```
 
 ### 7. SSH 秘密鍵のコピー

--- a/reverse-proxy/Makefile
+++ b/reverse-proxy/Makefile
@@ -1,0 +1,23 @@
+.PHONY: help
+help: ## ヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: up
+up: ## リバースプロキシを起動（web-proxy-netも自動作成）
+	docker network inspect web-proxy-net >/dev/null 2>&1 || docker network create web-proxy-net
+	docker compose up -d
+	@echo "✅ リバースプロキシを起動しました"
+
+.PHONY: down
+down: ## リバースプロキシを停止
+	docker compose down
+	@echo "✅ リバースプロキシを停止しました"
+
+.PHONY: logs
+logs: ## リバースプロキシのログを表示
+	docker compose logs -f
+
+.PHONY: reload
+reload: ## Caddyfileの設定を再読み込み
+	docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile
+	@echo "✅ Caddyfile を再読み込みしました"


### PR DESCRIPTION
## 概要

`reverse-proxy/` ディレクトリにMakefileを追加し、ディレクトリ単体で `/srv` にコピーするだけで運用可能な設計にする。

## 変更内容

- `reverse-proxy/Makefile` を新規作成（up, down, logs, reload, help）
- ルートMakefileから `proxy-*` コマンド4つを削除
- `prod-deploy` から `web-proxy-net` 作成処理を削除（reverse-proxy側の責務）
- README.md のリバースプロキシ操作手順・プロジェクト構造・デプロイ手順を更新
- `docs/vps-setup.md` のリバースプロキシ配置手順を更新（`scp -r` でディレクトリごとコピー、`make up` で起動）

## テスト方法

```bash
cd reverse-proxy/
make help  # コマンド一覧が表示されること
```

## チェックリスト

- [x] `reverse-proxy/` 配下のファイルだけで `make up` → Caddy起動が可能
- [x] ルートMakefileから `proxy-*` コマンドが削除済み
- [x] ドキュメント更新済み

Closes #73