### PR TITLE
docs: 本番デプロイ手順をreverse-proxy/を/srv/reverse-proxy/にコピーする手順に更新 (issue#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,16 +434,18 @@ vi .env.production
 
 #### 2. リバースプロキシの設定・起動
 
+リバースプロキシ（Caddy）はプロジェクトとは独立して `/srv/reverse-proxy/` で運用します（[VPS初期セットアップ](docs/vps-setup.md) 参照）。
+
 ```bash
-cd reverse-proxy/
+# reverse-proxy/ を /srv/reverse-proxy/ にコピー
+cp -r reverse-proxy/ /srv/reverse-proxy/
 
 # Caddyfileにドメイン名を設定
-vi Caddyfile
+vi /srv/reverse-proxy/Caddyfile
 
 # リバースプロキシを起動（web-proxy-netネットワークも自動作成）
+cd /srv/reverse-proxy/
 make up
-
-cd ..
 ```
 
 #### 3. アプリケーションのデプロイ


### PR DESCRIPTION
## 関連Issue

Closes #75

## 変更内容

README.md の本番デプロイ手順（ステップ2: リバースプロキシの設定・起動）を更新し、`reverse-proxy/` を `/srv/reverse-proxy/` にコピーして運用する手順に変更しました。

### 変更点

- `/srv/reverse-proxy/` で独立運用する旨の説明文と `docs/vps-setup.md` へのリンクを追加
- `cd reverse-proxy/` → `cp -r reverse-proxy/ /srv/reverse-proxy/` に変更（コピー手順を明示）
- `vi Caddyfile` → `vi /srv/reverse-proxy/Caddyfile` に変更（パスを明確化）
- `cd /srv/reverse-proxy/` で移動してから `make up` する手順に変更
- 不要な `cd ..` を削除

### 確認事項

- [x] README.md と docs/vps-setup.md の手順が整合している
- [x] Caddyfile は `yourdomain.com` のテンプレート状態のまま（変更不要）