### PR TITLE
fix(docker): 開発コンテナ起動時にserver.pidを削除する処理を追加 (issue#77)

### DIFF
--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -23,7 +23,7 @@ services:
       args:
         RUBY_VERSION: ${RUBY_VERSION}
         RAILS_VERSION: ${RAILS_VERSION}
-    command: bash -c "bin/setup && bin/dev"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/setup && bin/dev"
     volumes:
       - .:/app
       - bundle_cache:/usr/local/bundle


### PR DESCRIPTION
## 概要

開発環境のコンテナ起動時に古い `server.pid` を自動削除し、PID ファイル残存によるサーバー起動失敗を防止する。

## 変更内容

- `compose.development.yaml` の app サービスの `command` に `rm -f tmp/pids/server.pid` を追加

## テスト方法

```bash
make up
```

## チェックリスト

- [x] コーディング規約準拠

Closes #77