### PR TITLE
feat(makefile): SECRET_KEY_BASE生成用のprod-secretターゲットを追加 (issue#79)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,10 @@ prod-db-reset: ## 本番環境のデータベースをリセット（注意：�
 	docker compose -f compose.production.yaml --env-file .env.production exec app rails db:reset
 	@echo "✅ データベースをリセットしました"
 
+.PHONY: prod-secret
+prod-secret: ## SECRET_KEY_BASEを生成して表示
+	docker compose -f compose.production.yaml --env-file .env.production run --rm app bundle exec rails secret
+
 .PHONY: prod-ps
 prod-ps: ## 本番環境のコンテナ状態を表示
 	docker compose -f compose.production.yaml --env-file .env.production ps

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ vi .env.production
 ```
 
 **必須設定項目:**
-- `SECRET_KEY_BASE`: `docker compose -f compose.production.yaml run --rm app bundle exec rails secret` で生成
+- `SECRET_KEY_BASE`: `make prod-secret` で生成
 - `POSTGRES_PASSWORD`: ランダムな強力なパスワードに変更
 
 #### 2. リバースプロキシの設定・起動


### PR DESCRIPTION
## 概要

本番環境の初回セットアップ時に使う `SECRET_KEY_BASE` を `make prod-secret` で簡単に生成できるようにした。

## 変更内容

- Makefile に `prod-secret` ターゲットを追加（`rails secret` を実行して表示するだけ）
- README の本番デプロイ手順で、長い docker compose コマンドを `make prod-secret` に置き換え

## テスト方法

```bash
make help | grep prod-secret
```

## チェックリスト

- [x] `make help` に表示される
- [x] 既存の `prod-*` ターゲットと同じスタイル
- [x] README 更新済み

Closes #79