### PR TITLE
feat(makefile): テスト実行用のtestターゲットを追加 (issue#87)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,10 @@ down: ## コンテナを停止
 bash: ## railsapp コンテナに入る
 	docker compose -f compose.development.yaml --env-file .env.development exec railsapp bash
 
+.PHONY: test
+test: ## RSpecテストを実行
+	docker compose -f compose.development.yaml --env-file .env.development exec railsapp bundle exec rspec
+
 .PHONY: clean
 clean: ## このプロジェクトのDocker関連をクリーン（公式イメージは保持）
 	docker compose -f compose.development.yaml --env-file .env.development down -v --rmi local


### PR DESCRIPTION
## 概要

Makefileにテスト実行用の `make test` ターゲットを追加。

## 変更内容

- `make test` で railsapp コンテナ内の `bundle exec rspec` を実行できるようにした
- 開発用コマンドセクション（`up`, `down`, `bash` の並び）に配置

## テスト方法

```bash
make help  # testターゲットが表示されることを確認
make test  # RSpecが実行されることを確認
```

## チェックリスト

- [x] コーディング規約準拠
- [x] `make help` にターゲットが表示される

Closes #87