### PR TITLE
fix(makefile): make testでDATABASE_URLをtest用DBに上書き (issue#89)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,9 @@ bash: ## railsapp コンテナに入る
 
 .PHONY: test
 test: ## RSpecテストを実行
-	docker compose -f compose.development.yaml --env-file .env.development exec railsapp bundle exec rspec
+	docker compose -f compose.development.yaml --env-file .env.development exec \
+		-e DATABASE_URL=postgres://postgres:postgres@db:5432/railsapp-test \
+		railsapp bundle exec rspec
 
 .PHONY: clean
 clean: ## このプロジェクトのDocker関連をクリーン（公式イメージは保持）


### PR DESCRIPTION
## 概要

`make test` 実行時に `DATABASE_URL` をtest用データベースに上書きし、RSpecのDBエラーを防止する。

## 変更内容

- `make test` の `docker compose exec` に `-e DATABASE_URL=postgres://postgres:postgres@db:5432/railsapp-test` を追加

## 背景

`.env.development` の `DATABASE_URL` が `railsapp-development` を指しているため、RSpec実行時もdevelopment DBに接続しようとしてテストが失敗する。`docker compose exec -e` でtest実行時のみURLを上書きすることで解決。

## テスト方法

```bash
make test
```

## チェックリスト

- [x] 既存の `make up` / `make init` の動作に影響なし
- [x] コーディング規約準拠

Closes #89