### PR TITLE
chore: Stripe gemに関する記述を削除 (issue#93)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,11 +23,3 @@ POSTGRES_DB=railsapp-development
 
 # DATABASE_URL (Rails が自動的に使用)
 DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-
-# ==============================================
-# Stripe configuration (編集可能)
-# Stripe ダッシュボードから取得したキーを設定してください
-# https://dashboard.stripe.com/test/apikeys
-# ==============================================
-STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
-STRIPE_SECRET_KEY=sk_test_your_secret_key_here

--- a/.env.production
+++ b/.env.production
@@ -50,11 +50,3 @@ PORT=3000
 
 # ロケール設定
 LANG=ja_JP.UTF-8
-
-# ==============================================
-# Stripe configuration (本番環境用)
-# 本番環境ではライブキー (pk_live_..., sk_live_...) を使用してください
-# https://dashboard.stripe.com/apikeys
-# ==============================================
-STRIPE_PUBLISHABLE_KEY=pk_live_your_publishable_key_here
-STRIPE_SECRET_KEY=sk_live_your_secret_key_here

--- a/Makefile
+++ b/Makefile
@@ -23,24 +23,10 @@ init: ## 【削除予定】定番gemを含むRailsアプリケーションを作
 	fi
 	@echo "📦 定番gemを追加します..."
 	docker compose -f compose.development.yaml --env-file .env.development run --rm --workdir /app railsapp \
-	bash -c "bundle add mini_racer stripe devise kaminari rack-cors && \
+	bash -c "bundle add mini_racer devise kaminari rack-cors && \
 	bundle add pry-rails --group development && \
 	bundle add rspec-rails factory_bot_rails faker --group 'development,test'"
 	@echo "✅ 定番gemを追加しました"
-	@echo "📄 Stripe initializerを作成します..."
-	@mkdir -p config/initializers
-	@printf '%s\n' \
-		'# Stripe configuration' \
-		'# API keys are loaded from environment variables' \
-		'' \
-		'Rails.configuration.stripe = {' \
-		"  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY']," \
-		"  secret_key: ENV['STRIPE_SECRET_KEY']" \
-		'}' \
-		'' \
-		'Stripe.api_key = Rails.configuration.stripe[:secret_key]' \
-		> config/initializers/stripe.rb
-	@echo "✅ Stripe initializerを作成しました"
 	@echo "📄 CORS initializerを作成します..."
 	@printf '%s\n' \
 		'# CORS configuration' \

--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ make up
 
 **`make init` で追加される定番gem:**
 - `mini_racer`: Node.js不要のV8エンジン
-- `stripe`: 決済処理
 - `devise`: 認証（要手動セットアップ）
 - `kaminari`: ページネーション
 - `rack-cors`: CORS対応
@@ -109,7 +108,6 @@ make up
 - Rails 8にはデフォルトで `rubocop-rails-omakase` が含まれます
 
 **自動生成されるinitializer:**
-- `config/initializers/stripe.rb`: Stripe APIキー設定
 - `config/initializers/cors.rb`: CORS設定（開発環境向けデフォルト）
 
 **Deviseの手動セットアップ:**
@@ -128,11 +126,6 @@ rails db:migrate
 - フラッシュメッセージ (`app/views/layouts/application.html.erb`)
 
 詳細は `rails generate devise:install` 実行時に表示される指示を参照してください。
-
-**Stripeの初期設定:**
-- `config/initializers/stripe.rb` が自動作成されます
-- `.env.development` にサンプルのAPIキーが含まれています
-- 実際に使用する場合は、[Stripe Dashboard](https://dashboard.stripe.com/test/apikeys) から取得したAPIキーに置き換えてください
 
 ---
 


### PR DESCRIPTION
## 概要

不要になったStripe gemに関する記述をプロジェクト全体から削除。

## 変更内容

- `Makefile`: `bundle add` から `stripe` を削除、Stripe initializer作成ステップを削除
- `README.md`: 定番gemリスト・自動生成initializer・初期設定セクションからStripe記述を削除
- `.env.development`: Stripe configurationセクションを削除
- `.env.production`: Stripe configurationセクションを削除

## テスト方法

```bash
grep -ri "stripe" .  # 参照が残っていないこと
```

## チェックリスト

- [x] `grep -ri "stripe"` で参照ゼロ確認済み
- [x] 既存の `make init` の動作に影響なし（stripe以外のgemは維持）

Closes #93