### PR TITLE
chore: .env.productionから不要なLANG設定を削除 (issue#95)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -47,6 +47,3 @@ WEB_CONCURRENCY=2
 
 # ポート設定
 PORT=3000
-
-# ロケール設定
-LANG=ja_JP.UTF-8


### PR DESCRIPTION
## 概要

`.env.production` の不要な `LANG=ja_JP.UTF-8` を削除。

## 変更内容

- `.env.production`: ロケール設定セクション（`LANG=ja_JP.UTF-8`）を削除

## 背景

Railsの言語設定は `config/application.rb` の `config.i18n.default_locale` で行うものであり、`LANG` 環境変数はRailsの動作に影響しない。

## チェックリスト

- [x] 本番環境の動作に影響なし

Closes #95