### PR TITLE
chore: POSTGRES_USER/PASSWORDを両環境で統一 (issue#99)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,8 +17,8 @@ POSTGRES_VERSION=16-bookworm
 # ==============================================
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_USER=postgres-user
+POSTGRES_PASSWORD=postgres-password
 POSTGRES_DB=railsapp-development
 
 # DATABASE_URL (Rails が自動的に使用)

--- a/.env.production
+++ b/.env.production
@@ -18,8 +18,8 @@ POSTGRES_VERSION=16-bookworm
 # ==============================================
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
-POSTGRES_USER=rails
-POSTGRES_PASSWORD=change-this-password
+POSTGRES_USER=postgres-user
+POSTGRES_PASSWORD=postgres-password
 POSTGRES_DB=railsapp-production
 
 # DATABASE_URL (Rails が自動的に使用)

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ bash: ## railsapp コンテナに入る
 .PHONY: test
 test: ## RSpecテストを実行
 	docker compose -f compose.development.yaml --env-file .env.development exec \
-		-e DATABASE_URL=postgres://postgres:postgres@db:5432/railsapp-test \
+		-e DATABASE_URL=postgres://postgres-user:postgres-password@db:5432/railsapp-test \
 		railsapp bundle exec rspec
 
 .PHONY: clean


### PR DESCRIPTION
## 概要

`.env.development` と `.env.production` の `POSTGRES_USER` / `POSTGRES_PASSWORD` を `postgres-user` / `postgres-password` に統一。

## 変更内容

- `.env.development`: `postgres` / `postgres` → `postgres-user` / `postgres-password`
- `.env.production`: `rails` / `change-this-password` → `postgres-user` / `postgres-password`
- `Makefile`: `make test` の `DATABASE_URL` を新しい認証情報に合わせて更新

## チェックリスト

- [x] 両環境の値が一致
- [x] `make test` のハードコード値も更新済み

Closes #99