### PR TITLE
feat(makefile): make initにsquare.rb gemとinitializerを追加 (issue#101)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,3 +23,13 @@ POSTGRES_DB=railsapp-development
 
 # DATABASE_URL (Rails が自動的に使用)
 DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+
+# ==============================================
+# Square configuration (編集可能)
+# Square Developer Dashboardから取得したキーを設定してください
+# https://developer.squareup.com/apps
+# ==============================================
+SQUARE_ACCESS_TOKEN=your_square_access_token_here
+SQUARE_APPLICATION_ID=your_square_application_id_here
+SQUARE_LOCATION_ID=your_square_location_id_here
+SQUARE_ENVIRONMENT=sandbox

--- a/.env.production
+++ b/.env.production
@@ -44,3 +44,12 @@ RAILS_SERVE_STATIC_FILES=true
 # Puma設定
 RAILS_MAX_THREADS=5
 WEB_CONCURRENCY=2
+
+# ==============================================
+# Square configuration (本番環境用)
+# https://developer.squareup.com/apps
+# ==============================================
+# SQUARE_ACCESS_TOKEN=your_square_access_token_here
+# SQUARE_APPLICATION_ID=your_square_application_id_here
+# SQUARE_LOCATION_ID=your_square_location_id_here
+# SQUARE_ENVIRONMENT=production

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,25 @@ init: ## 【削除予定】定番gemを含むRailsアプリケーションを作
 	fi
 	@echo "📦 定番gemを追加します..."
 	docker compose -f compose.development.yaml --env-file .env.development run --rm --workdir /app railsapp \
-	bash -c "bundle add mini_racer devise kaminari rack-cors && \
+	bash -c "bundle add mini_racer square.rb devise kaminari rack-cors && \
 	bundle add pry-rails --group development && \
 	bundle add rspec-rails factory_bot_rails faker --group 'development,test'"
 	@echo "✅ 定番gemを追加しました"
+	@echo "📄 Square initializerを作成します..."
+	@mkdir -p config/initializers
+	@printf '%s\n' \
+		'require "square"' \
+		'' \
+		'SQUARE_CLIENT = if ENV["SQUARE_ACCESS_TOKEN"].present?' \
+		'  Square::Client.new(' \
+		'    token: ENV.fetch("SQUARE_ACCESS_TOKEN"),' \
+		'    base_url: ENV.fetch("SQUARE_ENVIRONMENT", "sandbox") == "production" ? Square::Environment::PRODUCTION : Square::Environment::SANDBOX' \
+		'  )' \
+		'end' \
+		'' \
+		'SQUARE_LOCATION_ID = ENV["SQUARE_LOCATION_ID"]' \
+		> config/initializers/square.rb
+	@echo "✅ Square initializerを作成しました"
 	@echo "📄 CORS initializerを作成します..."
 	@printf '%s\n' \
 		'# CORS configuration' \

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make up
 
 **`make init` で追加される定番gem:**
 - `mini_racer`: Node.js不要のV8エンジン
+- `square.rb`: Square決済
 - `devise`: 認証（要手動セットアップ）
 - `kaminari`: ページネーション
 - `rack-cors`: CORS対応
@@ -108,6 +109,7 @@ make up
 - Rails 8にはデフォルトで `rubocop-rails-omakase` が含まれます
 
 **自動生成されるinitializer:**
+- `config/initializers/square.rb`: Square API設定
 - `config/initializers/cors.rb`: CORS設定（開発環境向けデフォルト）
 
 **Deviseの手動セットアップ:**


### PR DESCRIPTION
## 概要

`make init` に Square決済用の `square.rb` gemの追加と `config/initializers/square.rb` の自動生成を組み込む。

## 変更内容

- `Makefile`: `bundle add` に `square.rb` を追加、Square initializer生成ステップを追加
- `.env.development`: `SQUARE_ACCESS_TOKEN`, `SQUARE_APPLICATION_ID`, `SQUARE_LOCATION_ID`, `SQUARE_ENVIRONMENT` のプレースホルダーを追加
- `.env.production`: Square環境変数をコメントアウト状態で追加（`SQUARE_APPLICATION_ID` 含む）
- `README.md`: 定番gemリストと自動生成initializerリストに追記

## テスト方法

```bash
make init  # square.rb gemがインストールされ、config/initializers/square.rb が生成されること
```

## チェックリスト

- [x] norn_osの実装を参考に実装
- [x] コーディング規約準拠
- [x] ドキュメント更新

Closes #101