### PR TITLE
feat(docker): build-baseステージにNode.jsを追加し、mini_racerを削除 (issue#103)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -9,6 +9,9 @@ RUBY_VERSION=3.3.6
 # Rails version (編集可能)
 RAILS_VERSION=8.0.4
 
+# Node.js version (編集可能)
+NODE_VERSION=24
+
 # PostgreSQL version (編集可能)
 POSTGRES_VERSION=16-bookworm
 

--- a/.env.production
+++ b/.env.production
@@ -6,8 +6,11 @@
 # Ruby version
 RUBY_VERSION=3.3.6
 
-# Rails version  
+# Rails version
 RAILS_VERSION=8.0.4
+
+# Node.js version
+NODE_VERSION=24
 
 # PostgreSQL version
 POSTGRES_VERSION=16-bookworm

--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -2,9 +2,19 @@
 # check=error=true
 
 # ============================================
+# グローバル ARG - 最初の FROM より前に宣言
+# ============================================
+ARG NODE_VERSION
+ARG RUBY_VERSION
+
+# ============================================
+# Node.js - 公式イメージからバイナリを取得
+# ============================================
+FROM node:${NODE_VERSION:-24}-slim AS node
+
+# ============================================
 # Base ステージ - 最小限のランタイム依存関係
 # ============================================
-ARG RUBY_VERSION
 FROM ruby:${RUBY_VERSION:-3.3.6}-slim AS base
 
 WORKDIR /app
@@ -20,11 +30,17 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # ============================================
-# Development ステージ - ローカル開発環境用
+# Build-base ステージ - ビルド共通基盤
 # ============================================
-FROM base AS development
+FROM base AS build-base
 
-# ビルドツールと開発ツールをインストール
+# Node.js をコピー（ビルド時のみ必要）
+COPY --from=node /usr/local/bin/node /usr/local/bin/
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# ビルドツールをインストール
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -32,6 +48,17 @@ RUN apt-get update -qq \
         libpq-dev \
         libyaml-dev \
         pkg-config \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# ============================================
+# Development ステージ - ローカル開発環境用
+# ============================================
+FROM build-base AS development
+
+# 開発用ツールを追加インストール
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
         less \
         vim \
     && apt-get clean \
@@ -44,18 +71,7 @@ RUN gem install rails -v ${RAILS_VERSION} --no-document
 # ============================================
 # Production-builder ステージ - アプリケーションビルド用
 # ============================================
-FROM base AS production-builder
-
-# ビルドに必要なパッケージをインストール
-RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        git \
-        libpq-dev \
-        libyaml-dev \
-        pkg-config \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+FROM build-base AS production-builder
 
 # Gemfile をコピーして gem をインストール
 COPY Gemfile Gemfile.lock ./

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ init: ## 【削除予定】定番gemを含むRailsアプリケーションを作
 	fi
 	@echo "📦 定番gemを追加します..."
 	docker compose -f compose.development.yaml --env-file .env.development run --rm --workdir /app railsapp \
-	bash -c "bundle add mini_racer square.rb devise kaminari rack-cors && \
+	bash -c "bundle add square.rb devise kaminari rack-cors && \
 	bundle add pry-rails --group development && \
 	bundle add rspec-rails factory_bot_rails faker --group 'development,test'"
 	@echo "✅ 定番gemを追加しました"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 | PostgreSQL | 16-bookworm | データベース |
 | Docker | 20.10+ | コンテナ実行環境 |
 | Docker Compose | 2.0+ | 複数コンテナ管理 |
+| Node.js | 24 | JavaScript ランタイム（ビルド時のみ） |
 | Tailwind CSS | - | CSSフレームワーク |
 | Import maps | - | JavaScript管理 |
 
@@ -99,7 +100,6 @@ make up
 ```
 
 **`make init` で追加される定番gem:**
-- `mini_racer`: Node.js不要のV8エンジン
 - `square.rb`: Square決済
 - `devise`: 認証（要手動セットアップ）
 - `kaminari`: ページネーション
@@ -232,6 +232,7 @@ Internet
 **開発環境（.env.development）:**
 - `RUBY_VERSION`: Ruby version (default: 3.3.6)
 - `RAILS_VERSION`: Rails version (default: 8.0.4)
+- `NODE_VERSION`: Node.js version (default: 24)
 - `POSTGRES_VERSION`: PostgreSQL version (default: 16-bookworm)
 - `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`: Database credentials
 - `DATABASE_URL`: PostgreSQL connection URL (auto-generated)

--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -23,6 +23,7 @@ services:
       args:
         RUBY_VERSION: ${RUBY_VERSION}
         RAILS_VERSION: ${RAILS_VERSION}
+        NODE_VERSION: ${NODE_VERSION}
     command: bash -c "rm -f tmp/pids/server.pid && bin/setup && bin/dev"
     volumes:
       - .:/app

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -24,6 +24,7 @@ services:
       args:
         RUBY_VERSION: ${RUBY_VERSION}
         RAILS_VERSION: ${RAILS_VERSION}
+        NODE_VERSION: ${NODE_VERSION}
     env_file:
       - .env.production
     expose:


### PR DESCRIPTION
## 概要

Dockerfile.rails に Node.js インストール用の `build-base` 中間ステージを追加し、不要になった `mini_racer` gem を削除。また、DB ヘルスチェックのログノイズを修正。

## 変更内容

- Dockerfile.rails: グローバル ARG 宣言を追加し、`node` ステージと `build-base` 中間ステージを新設
- compose.development.yaml / compose.production.yaml: `NODE_VERSION` を build args に追加、ヘルスチェックに `-d postgres` を追加
- .env.development / .env.production: `NODE_VERSION=24` を追加
- Makefile: `make init` から `mini_racer` の `bundle add` を削除
- README.md: 技術スタックに Node.js を追加、定番gem一覧から `mini_racer` を削除、環境変数一覧に `NODE_VERSION` を追加

### ステージ構成

```
node (公式イメージ)
         ↓ COPY --from
base → build-base (+Node.js, +ビルドツール)
         ├→ development
         └→ production-builder
base → production  ← Node.js を含まない（軽量）
```

### mini_racer 削除の理由

Rails 8 + importmap + Stimulus + ViewComponent の構成ではサーバー側 JS ランタイムが不要。

### ヘルスチェック修正

`pg_isready -U ${POSTGRES_USER}` がユーザー名と同名の DB に接続しようとし `FATAL: database "postgres-user" does not exist` が10秒ごとにログに出力されていた。`-d postgres` を追加して常に存在する `postgres` DB を指定。

## テスト方法

```bash
make clean
make up
# http://localhost:3000 でアプリケーション動作確認
make bash
node --version  # Node.js がインストールされていることを確認
# DB ログに "database does not exist" エラーが出ないことを確認
```

## チェックリスト

- [x] build-base ステージが追加されている
- [x] Node.js バージョンが ARG + .env で管理されている
- [x] development / production-builder が build-base を継承している
- [x] production ステージに Node.js が含まれない
- [x] mini_racer が Makefile から削除されている
- [x] DB ヘルスチェックのログノイズが解消されている
- [x] ドキュメント更新（README.md）

Closes #103