### PR TITLE
chore(docker): composeのdbサービス名をpostgresdbにリネーム (issue#105)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -18,7 +18,7 @@ POSTGRES_VERSION=16-bookworm
 # ==============================================
 # Database configuration (編集可能)
 # ==============================================
-POSTGRES_HOST=db
+POSTGRES_HOST=postgresdb
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres-user
 POSTGRES_PASSWORD=postgres-password

--- a/.env.production
+++ b/.env.production
@@ -17,9 +17,9 @@ POSTGRES_VERSION=16-bookworm
 
 # ==============================================
 # Database configuration (本番環境用)
-# compose.production.yamlのdbサービスに接続
+# compose.production.yamlのpostgresdbサービスに接続
 # ==============================================
-POSTGRES_HOST=db
+POSTGRES_HOST=postgresdb
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres-user
 POSTGRES_PASSWORD=postgres-password

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,17 +160,17 @@ bundle exec rspec
 
 **開発環境:**
 ```
-railsapp (Rails, :3000) → db (PostgreSQL, :5432)
+railsapp (Rails, :3000) → postgresdb (PostgreSQL, :5432)
 ```
 
 **本番環境（リバースプロキシ独立構成）:**
 ```
-caddy (reverse-proxy/, :80/:443) →[web-proxy-net]→ railsapp (:3000) →[internal]→ db (:5432)
+caddy (reverse-proxy/, :80/:443) →[web-proxy-net]→ railsapp (:3000) →[internal]→ postgresdb (:5432)
 ```
 
 - **caddy**: `reverse-proxy/` で独立管理、Let's EncryptでSSL自動化
 - **railsapp**: ポート3000（internal + web-proxy-net）
-- **db**: ポート5432（internalのみ）、postgres_dataボリュームで永続化
+- **postgresdb**: ポート5432（internalのみ）、postgres_dataボリュームで永続化
 
 ### 環境変数管理
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ bash: ## railsapp コンテナに入る
 .PHONY: test
 test: ## RSpecテストを実行
 	docker compose -f compose.development.yaml --env-file .env.development exec \
-		-e DATABASE_URL=postgres://postgres-user:postgres-password@db:5432/railsapp-test \
+		-e DATABASE_URL=postgres://postgres-user:postgres-password@postgresdb:5432/railsapp-test \
 		railsapp bundle exec rspec
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ rails db:migrate
 │  railsapp (Rails アプリケーション)     │
 │  - ポート: 3000                      │
 │  - ボリューム: カレントディレクトリ    │
-│  - 依存: db サービス                 │
+│  - 依存: postgresdb サービス         │
 └─────────────────────────────────────┘
               ↓
 ┌─────────────────────────────────────┐
-│  db (PostgreSQL)                    │
+│  postgresdb (PostgreSQL)            │
 │  - ポート: 5432                      │
 │  - ボリューム: postgres_data         │
 │  - ヘルスチェック有効                │
@@ -175,11 +175,11 @@ Internet
 │  - ポート: 3000（内部のみ）          │
 │  - ネットワーク: internal,           │
 │                  web-proxy-net       │
-│  - 依存: db サービス                 │
+│  - 依存: postgresdb サービス         │
 └─────────────────────────────────────┘
               ↓ internal
 ┌─────────────────────────────────────┐
-│  db (PostgreSQL)                    │
+│  postgresdb (PostgreSQL)            │
 │  - ポート: 5432（内部のみ）          │
 │  - ネットワーク: internal            │
 │  - ボリューム: postgres_data         │
@@ -189,8 +189,8 @@ Internet
 
 **構成ファイル:**
 - `reverse-proxy/compose.yaml` + `reverse-proxy/Caddyfile`: リバースプロキシ（独立管理）
-- `compose.development.yaml` + `.env.development`: 開発環境（railsapp + db）
-- `compose.production.yaml` + `.env.production`: 本番環境（railsapp + db）
+- `compose.development.yaml` + `.env.development`: 開発環境（railsapp + postgresdb）
+- `compose.production.yaml` + `.env.production`: 本番環境（railsapp + postgresdb）
 
 #### 1. railsapp サービス（`Dockerfile.rails`）
 
@@ -200,7 +200,7 @@ Internet
 - デフォルトで `bin/dev` を実行（Railsサーバー起動 + アセットビルド）
 - アクセス: http://localhost:3000
 
-#### 2. db サービス
+#### 2. postgresdb サービス
 
 - PostgreSQLデータベース
 - データは `postgres_data` ボリュームに永続化
@@ -265,7 +265,7 @@ docker compose -f compose.development.yaml --env-file .env.development ps
 
 # ログ表示
 docker compose -f compose.development.yaml --env-file .env.development logs railsapp
-docker compose -f compose.development.yaml --env-file .env.development logs db
+docker compose -f compose.development.yaml --env-file .env.development logs postgresdb
 
 # 利用可能なコマンド一覧を表示
 make help
@@ -356,7 +356,7 @@ make help  # 全コマンド確認
 |---------|------|
 | `reverse-proxy/compose.yaml` | リバースプロキシ用 Docker Compose 設定 |
 | `reverse-proxy/Caddyfile` | Caddy リバースプロキシ設定（SSL自動化） |
-| `compose.production.yaml` | 本番環境用 Docker Compose 設定（app + db） |
+| `compose.production.yaml` | 本番環境用 Docker Compose 設定（app + postgresdb） |
 | `.env.production` | 本番環境用環境変数（SECRET_KEY_BASE等を要変更） |
 | `Dockerfile.rails` | 本番ステージを含むマルチステージビルド |
 
@@ -454,7 +454,7 @@ make prod-deploy
 │   ├── Caddyfile             # Caddy リバースプロキシ設定
 │   └── Makefile              # リバースプロキシ操作コマンド
 ├── compose.development.yaml  # 開発環境用 Docker Compose 設定
-├── compose.production.yaml   # 本番環境用 Docker Compose 設定（app + db）
+├── compose.production.yaml   # 本番環境用 Docker Compose 設定（app + postgresdb）
 ├── Dockerfile.rails          # Railsコンテナ定義（マルチステージビルド）
 ├── Makefile                  # 開発ショートカット
 ├── CONTRIBUTING.md           # 開発ガイドライン・ワークフロー

--- a/compose.development.yaml
+++ b/compose.development.yaml
@@ -1,5 +1,5 @@
 services:
-  db:
+  postgresdb:
     image: postgres:${POSTGRES_VERSION}
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -33,7 +33,7 @@ services:
     env_file:
       - .env.development
     depends_on:
-      db:
+      postgresdb:
         condition: service_healthy
     stdin_open: true
     tty: true

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -1,5 +1,5 @@
 services:
-  db:
+  postgresdb:
     image: postgres:${POSTGRES_VERSION}
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -30,7 +30,7 @@ services:
     expose:
       - "3000"
     depends_on:
-      db:
+      postgresdb:
         condition: service_healthy
     networks:
       - internal


### PR DESCRIPTION
## 概要

Docker Composeのデータベースサービス名を `db` から `postgresdb` に変更し、サービスの役割を明確化。

## 変更内容

- `compose.development.yaml` / `compose.production.yaml`: サービス名 `db` → `postgresdb`、`depends_on` 更新
- `.env.development` / `.env.production`: `POSTGRES_HOST=postgresdb` に更新
- `Makefile`: テスト用 `DATABASE_URL` のホスト名を更新
- `README.md` / `CLAUDE.md`: アーキテクチャ図・ドキュメントの参照を更新

## テスト方法

```bash
make up
# コンテナが正常に起動し、railsappがpostgresdbに接続できることを確認
docker compose -f compose.development.yaml --env-file .env.development ps
```

## チェックリスト

- [x] コーディング規約準拠
- [x] ドキュメント更新

Closes #105