### PR TITLE
chore(deps): Ruby 3.4.8, Rails 8.1.2, PostgreSQL 17に更新 (issue#107)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,16 +4,16 @@
 # ==============================================
 
 # Ruby version (編集可能)
-RUBY_VERSION=3.3.6
+RUBY_VERSION=3.4.8
 
 # Rails version (編集可能)
-RAILS_VERSION=8.0.4
+RAILS_VERSION=8.1.2
 
 # Node.js version (編集可能)
 NODE_VERSION=24
 
 # PostgreSQL version (編集可能)
-POSTGRES_VERSION=16-bookworm
+POSTGRES_VERSION=17-bookworm
 
 # ==============================================
 # Database configuration (編集可能)

--- a/.env.production
+++ b/.env.production
@@ -4,16 +4,16 @@
 # ==============================================
 
 # Ruby version
-RUBY_VERSION=3.3.6
+RUBY_VERSION=3.4.8
 
 # Rails version
-RAILS_VERSION=8.0.4
+RAILS_VERSION=8.1.2
 
 # Node.js version
 NODE_VERSION=24
 
 # PostgreSQL version
-POSTGRES_VERSION=16-bookworm
+POSTGRES_VERSION=17-bookworm
 
 # ==============================================
 # Database configuration (本番環境用)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@
 
 ### 主要技術
 
-- **Ruby**: 3.3.6
-- **Rails**: 8.0.4
-- **PostgreSQL**: 16-bookworm
+- **Ruby**: 3.4.8
+- **Rails**: 8.1.2
+- **PostgreSQL**: 17-bookworm
 - **Docker & Docker Compose**
 - **Tailwind CSS**、**Import maps**
 

--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -15,7 +15,7 @@ FROM node:${NODE_VERSION:-24}-slim AS node
 # ============================================
 # Base ステージ - 最小限のランタイム依存関係
 # ============================================
-FROM ruby:${RUBY_VERSION:-3.3.6}-slim AS base
+FROM ruby:${RUBY_VERSION:-3.4.8}-slim AS base
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
 
 | 技術 | バージョン | 用途 |
 |-----|----------|------|
-| Ruby | 3.3.6 | プログラミング言語 |
-| Rails | 8.0.4 | Webフレームワーク |
-| PostgreSQL | 16-bookworm | データベース |
+| Ruby | 3.4.8 | プログラミング言語 |
+| Rails | 8.1.2 | Webフレームワーク |
+| PostgreSQL | 17-bookworm | データベース |
 | Docker | 20.10+ | コンテナ実行環境 |
 | Docker Compose | 2.0+ | 複数コンテナ管理 |
 | Node.js | 24 | JavaScript ランタイム（ビルド時のみ） |
@@ -230,10 +230,10 @@ Internet
 #### 環境変数一覧
 
 **開発環境（.env.development）:**
-- `RUBY_VERSION`: Ruby version (default: 3.3.6)
-- `RAILS_VERSION`: Rails version (default: 8.0.4)
+- `RUBY_VERSION`: Ruby version (default: 3.4.8)
+- `RAILS_VERSION`: Rails version (default: 8.1.2)
 - `NODE_VERSION`: Node.js version (default: 24)
-- `POSTGRES_VERSION`: PostgreSQL version (default: 16-bookworm)
+- `POSTGRES_VERSION`: PostgreSQL version (default: 17-bookworm)
 - `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`: Database credentials
 - `DATABASE_URL`: PostgreSQL connection URL (auto-generated)
 


### PR DESCRIPTION
## 概要

`.env` ファイルおよび関連ドキュメントのソフトウェアバージョンを最新の安定版に更新。

## 変更内容

| ソフトウェア | 変更前 | 変更後 | サポート期限 |
|---|---|---|---|
| Ruby | 3.3.6 | 3.4.8 | 2028/3 |
| Rails | 8.0.4 | 8.1.2 | 2027/10（セキュリティ） |
| PostgreSQL | 16-bookworm | 17-bookworm | 2029/11 |
| Node.js | 24 | 24（変更なし） | 2028/4 |

## 変更ファイル

- `.env.development` - バージョン更新
- `.env.production` - バージョン更新
- `Dockerfile.rails` - デフォルト値更新
- `README.md` - バージョン表記更新
- `CLAUDE.md` - バージョン表記更新

## 更新理由

- Rails 8.0のバグ修正サポートが2026/5に終了するため8.1へ移行
- Ruby 3.4はRails 8.1と互換性があり、3.3より1年長いサポート期間
- PostgreSQL 17は安定しており、16より1年長いサポート期間

Closes #107