### PR TITLE
fix(docker): build-baseステージにzlib1g-devを追加 (issue#109)

### DIFF
--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -48,6 +48,7 @@ RUN apt-get update -qq \
         libpq-dev \
         libyaml-dev \
         pkg-config \
+        zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 


### PR DESCRIPTION
## 概要

`make init` 実行時に `zlib` gem のネイティブ拡張ビルドが失敗する問題を修正。

## 変更内容

- `Dockerfile.rails` の build-base ステージに `zlib1g-dev` パッケージを追加

## 背景

`square.rb` → `apimatic_faraday_client_adapter` → `faraday-gzip` → `zlib` の依存チェーンにより `zlib` gem が必要だが、ネイティブ拡張のビルドに必要な zlib 開発ヘッダ (`zlib1g-dev`) が Docker イメージに含まれていなかった。

## テスト方法

```bash
docker compose -f compose.development.yaml --env-file .env.development build --no-cache
make init
```

## チェックリスト

- [x] `Dockerfile.rails` に `zlib1g-dev` を追加
- [ ] `make init` が正常に完了することを確認

Closes #109