### PR TITLE
feat(makefile): 本番DBバックアップ用のmakeコマンドを追加 (issue#112)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ prod-backup: ## 本番DBのバックアップを作成（BACKUP_RETENTION_DAYS=7
 	@mkdir -p $(BACKUP_DIR)
 	@FILENAME=$(BACKUP_DIR)/$$(date +%Y%m%d_%H%M%S).sql.gz; \
 	$(PROD_COMPOSE) exec -T postgresdb \
-		pg_dump --clean --if-exists -U "$$POSTGRES_USER" "$$POSTGRES_DB" | gzip > "$$FILENAME" && \
+		bash -c 'pg_dump --clean --if-exists -U $$POSTGRES_USER $$POSTGRES_DB' | gzip > "$$FILENAME" && \
 	echo "✅ バックアップを作成しました: $$FILENAME ($$(du -h "$$FILENAME" | cut -f1))"
 	@find $(BACKUP_DIR) -name "*.sql.gz" -mtime +$(BACKUP_RETENTION_DAYS) -delete 2>/dev/null; \
 	echo "🗑️  $(BACKUP_RETENTION_DAYS)日以上前のバックアップを削除しました"

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,70 @@ prod-secret: ## SECRET_KEY_BASEを生成して表示
 .PHONY: prod-ps
 prod-ps: ## 本番環境のコンテナ状態を表示
 	docker compose -f compose.production.yaml --env-file .env.production ps
+
+# ==============================================
+# バックアップ用コマンド（本番環境）
+# ==============================================
+
+BACKUP_DIR := backups
+BACKUP_RETENTION_DAYS ?= 7
+BACKUP_CRON_SCHEDULE ?= 0 2 * * *
+PROD_COMPOSE := docker compose -f compose.production.yaml --env-file .env.production
+
+.PHONY: prod-backup
+prod-backup: ## 本番DBのバックアップを作成（BACKUP_RETENTION_DAYS=7で世代管理）
+	@mkdir -p $(BACKUP_DIR)
+	@FILENAME=$(BACKUP_DIR)/$$(date +%Y%m%d_%H%M%S).sql.gz; \
+	$(PROD_COMPOSE) exec -T postgresdb \
+		pg_dump --clean --if-exists -U "$$POSTGRES_USER" "$$POSTGRES_DB" | gzip > "$$FILENAME" && \
+	echo "✅ バックアップを作成しました: $$FILENAME ($$(du -h "$$FILENAME" | cut -f1))"
+	@find $(BACKUP_DIR) -name "*.sql.gz" -mtime +$(BACKUP_RETENTION_DAYS) -delete 2>/dev/null; \
+	echo "🗑️  $(BACKUP_RETENTION_DAYS)日以上前のバックアップを削除しました"
+
+.PHONY: prod-backup-list
+prod-backup-list: ## バックアップ一覧を表示
+	@if [ -d $(BACKUP_DIR) ] && ls $(BACKUP_DIR)/*.sql.gz 1>/dev/null 2>&1; then \
+		echo "📋 バックアップ一覧:"; \
+		ls -lh $(BACKUP_DIR)/*.sql.gz; \
+	else \
+		echo "バックアップがありません"; \
+	fi
+
+.PHONY: prod-backup-restore
+prod-backup-restore: ## バックアップからリストア（FILE=backups/YYYYMMDD_HHMMSS.sql.gz）
+	@if [ -z "$(FILE)" ]; then \
+		echo "❌ FILEを指定してください: make prod-backup-restore FILE=backups/YYYYMMDD_HHMMSS.sql.gz"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(FILE)" ]; then \
+		echo "❌ ファイルが見つかりません: $(FILE)"; \
+		exit 1; \
+	fi
+	@echo "⚠️  警告: データベースを $(FILE) から復元します。既存のデータは上書きされます。続行しますか? [y/N]" && read ans && [ $${ans:-N} = y ]
+	gunzip -c $(FILE) | $(PROD_COMPOSE) exec -T postgresdb \
+		bash -c 'psql -U $$POSTGRES_USER $$POSTGRES_DB'
+	@echo "✅ リストアが完了しました: $(FILE)"
+
+.PHONY: prod-backup-cron
+prod-backup-cron: ## pg_dumpのcronジョブを設定（デフォルト: 毎日2:00、7日間保持）
+	@mkdir -p $(BACKUP_DIR)
+	@CRON_CMD="$(BACKUP_CRON_SCHEDULE) cd $(CURDIR) && make prod-backup >> $(CURDIR)/$(BACKUP_DIR)/cron.log 2>&1"; \
+	(crontab -l 2>/dev/null | grep -v "make prod-backup"; echo "$$CRON_CMD") | crontab -
+	@echo "✅ cronジョブを設定しました"
+	@echo "   スケジュール: $(BACKUP_CRON_SCHEDULE)"
+	@echo "   保持日数: $(BACKUP_RETENTION_DAYS)日"
+	@echo "   ログ: $(CURDIR)/$(BACKUP_DIR)/cron.log"
+	@crontab -l | grep "prod-backup"
+
+.PHONY: prod-backup-cron-remove
+prod-backup-cron-remove: ## pg_dumpのcronジョブを削除
+	@(crontab -l 2>/dev/null | grep -v "make prod-backup") | crontab -
+	@echo "✅ cronジョブを削除しました"
+
+.PHONY: prod-backup-cron-status
+prod-backup-cron-status: ## cronジョブの状態を表示
+	@echo "📋 現在のcronジョブ:"
+	@crontab -l 2>/dev/null | grep "prod-backup" || echo "   設定されていません"
+	@echo ""
+	@echo "📋 最新のcronログ:"
+	@if [ -f $(BACKUP_DIR)/cron.log ]; then tail -5 $(BACKUP_DIR)/cron.log; else echo "   ログがありません"; fi

--- a/README.md
+++ b/README.md
@@ -344,6 +344,38 @@ make prod-ps
 make help  # 全コマンド確認
 ```
 
+### バックアップ
+
+```bash
+# バックアップを即時作成（gzip圧縮、7日以上の古いファイルを自動削除）
+make prod-backup
+
+# バックアップ一覧を表示
+make prod-backup-list
+
+# バックアップからリストア
+make prod-backup-restore FILE=backups/20260311_020000.sql.gz
+
+# cronジョブを設定（デフォルト: 毎日2:00）
+make prod-backup-cron
+
+# cronジョブを削除
+make prod-backup-cron-remove
+
+# cronジョブの状態とログを表示
+make prod-backup-cron-status
+```
+
+**設定変更:**
+
+```bash
+# 保持日数を変更（デフォルト: 7日）
+make prod-backup BACKUP_RETENTION_DAYS=30
+
+# cronスケジュールを変更（例: 毎日3:00）
+make prod-backup-cron BACKUP_CRON_SCHEDULE="0 3 * * *"
+```
+
 ---
 
 ## 本番環境デプロイ
@@ -423,7 +455,14 @@ make prod-deploy
 4. コンテナを起動
 5. データベースのセットアップ（`db:create db:migrate db:seed`）
 
-#### 4. 確認
+#### 4. バックアップの設定
+
+```bash
+# 定期バックアップを設定（毎日2:00、7日間保持）
+make prod-backup-cron
+```
+
+#### 5. 確認
 
 アプリケーション: `https://yourdomain.com`
 


### PR DESCRIPTION
## 概要

本番VPSでのPostgreSQLバックアップをMakefileコマンドで管理できるようにした。

## 変更内容

- `make prod-backup`: pg_dumpを即時実行（gzip圧縮、`--clean --if-exists`付き、世代管理）
- `make prod-backup-list`: バックアップ一覧を表示
- `make prod-backup-restore FILE=...`: 指定ファイルからリストア（確認プロンプト付き）
- `make prod-backup-cron`: crontabにジョブを登録（デフォルト毎日2:00、7日間保持）
- `make prod-backup-cron-remove`: cronジョブを削除
- `make prod-backup-cron-status`: cronジョブの状態とログを表示
- README.mdにバックアップセクションを追記（コマンド一覧 + デプロイ手順に組み込み）

## 設定変更

保持日数とスケジュールはMake変数でカスタマイズ可能:

```bash
make prod-backup BACKUP_RETENTION_DAYS=30
make prod-backup-cron BACKUP_CRON_SCHEDULE="0 3 * * *"
```

## テスト方法

```bash
# helpに全コマンドが表示されること
make help

# VPS上でバックアップ→リストアの動作確認
make prod-backup
make prod-backup-list
make prod-backup-restore FILE=backups/YYYYMMDD_HHMMSS.sql.gz

# cron設定の確認
make prod-backup-cron
make prod-backup-cron-status
make prod-backup-cron-remove
```

## チェックリスト

- [x] Makefileにバックアップターゲットを追加
- [x] README.mdにバックアップセクションを追記
- [x] デプロイ手順にバックアップ設定ステップを追加
- [x] `make help` に全コマンドが表示される

Closes #112