### PR TITLE
feat(makefile): 本番DBバックアップ用のmakeコマンドを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ prod-backup-restore: ## 指定ファイルからDBをリストア（例: make pr
 
 .PHONY: prod-backup-cron
 prod-backup-cron: ## cronにバックアップジョブを登録（デフォルト: 毎日2時）
-	@CRON_CMD="$(BACKUP_CRON_SCHEDULE) cd $$(pwd) && make prod-backup >> /var/log/backup.log 2>&1"; \
+	@CRON_CMD="$(BACKUP_CRON_SCHEDULE) cd $$(pwd) && make prod-backup >> logs/backup.log 2>&1"; \
 	( crontab -l 2>/dev/null | grep -v "make prod-backup"; echo "$$CRON_CMD" ) | crontab -
 	@echo "✅ cronジョブを登録しました: $(BACKUP_CRON_SCHEDULE)"
 
@@ -207,4 +207,4 @@ prod-backup-cron-status: ## cronジョブの状態と最新ログを表示
 	@crontab -l 2>/dev/null | grep "make prod-backup" || echo "バックアップcronジョブは登録されていません"
 	@echo ""
 	@echo "=== 最新のcronログ (直近20行) ==="
-	@tail -n 20 /var/log/backup.log 2>/dev/null || echo "ログファイルがありません"
+	@tail -n 20 logs/backup.log 2>/dev/null || echo "ログファイルがありません"

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,6 @@ prod-ps: ## 本番環境のコンテナ状態を表示
 # バックアップ用コマンド
 # ==============================================
 
-PROD_COMPOSE := docker compose -f compose.production.yaml --env-file .env.production
 BACKUP_DIR := backups
 BACKUP_RETENTION_DAYS ?= 7
 BACKUP_CRON_SCHEDULE ?= 0 2 * * *
@@ -174,7 +173,7 @@ BACKUP_POSTGRES_DB := $(shell grep '^POSTGRES_DB=' .env.production 2>/dev/null |
 prod-backup: ## 本番DBをバックアップ（即時実行）
 	@mkdir -p $(BACKUP_DIR)
 	@FILE=$(BACKUP_DIR)/$$(date +%Y%m%d_%H%M%S).sql.gz; \
-	$(PROD_COMPOSE) exec -T db pg_dump --clean --if-exists -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB) | gzip > $$FILE && \
+	docker compose -f compose.production.yaml --env-file .env.production exec -T db pg_dump --clean --if-exists -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB) | gzip > $$FILE && \
 	echo "✅ バックアップを作成しました: $$FILE" || { echo "❌ バックアップに失敗しました"; rm -f $$FILE; exit 1; }
 	@find $(BACKUP_DIR) -name "*.sql.gz" -mtime +$(BACKUP_RETENTION_DAYS) -delete && \
 	echo "🗑️  $(BACKUP_RETENTION_DAYS)日以上前のバックアップを削除しました"
@@ -188,7 +187,7 @@ prod-backup-restore: ## 指定ファイルからDBをリストア（例: make pr
 	@test -n "$(FILE)" || { echo "エラー: FILE=<バックアップファイルパス> を指定してください"; exit 1; }
 	@test -f "$(FILE)" || { echo "エラー: ファイルが見つかりません: $(FILE)"; exit 1; }
 	@echo "⚠️  警告: $(FILE) からリストアします。現在のデータが上書きされます。続行しますか? [y/N]" && read ans && [ $${ans:-N} = y ]
-	@gunzip -c $(FILE) | $(PROD_COMPOSE) exec -T db psql -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB)
+	@gunzip -c $(FILE) | docker compose -f compose.production.yaml --env-file .env.production exec -T db psql -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB)
 	@echo "✅ リストアが完了しました"
 
 .PHONY: prod-backup-cron

--- a/Makefile
+++ b/Makefile
@@ -158,3 +158,54 @@ prod-db-reset: ## 本番環境のデータベースをリセット（注意：�
 .PHONY: prod-ps
 prod-ps: ## 本番環境のコンテナ状態を表示
 	docker compose -f compose.production.yaml --env-file .env.production ps
+
+# ==============================================
+# バックアップ用コマンド
+# ==============================================
+
+PROD_COMPOSE := docker compose -f compose.production.yaml --env-file .env.production
+BACKUP_DIR := backups
+BACKUP_RETENTION_DAYS ?= 7
+BACKUP_CRON_SCHEDULE ?= 0 2 * * *
+BACKUP_POSTGRES_USER := $(shell grep '^POSTGRES_USER=' .env.production 2>/dev/null | cut -d= -f2)
+BACKUP_POSTGRES_DB := $(shell grep '^POSTGRES_DB=' .env.production 2>/dev/null | cut -d= -f2)
+
+.PHONY: prod-backup
+prod-backup: ## 本番DBをバックアップ（即時実行）
+	@mkdir -p $(BACKUP_DIR)
+	@FILE=$(BACKUP_DIR)/$$(date +%Y%m%d_%H%M%S).sql.gz; \
+	$(PROD_COMPOSE) exec -T db pg_dump --clean --if-exists -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB) | gzip > $$FILE && \
+	echo "✅ バックアップを作成しました: $$FILE" || { echo "❌ バックアップに失敗しました"; rm -f $$FILE; exit 1; }
+	@find $(BACKUP_DIR) -name "*.sql.gz" -mtime +$(BACKUP_RETENTION_DAYS) -delete && \
+	echo "🗑️  $(BACKUP_RETENTION_DAYS)日以上前のバックアップを削除しました"
+
+.PHONY: prod-backup-list
+prod-backup-list: ## バックアップ一覧をサイズ付きで表示
+	@ls -lh $(BACKUP_DIR)/*.sql.gz 2>/dev/null || echo "バックアップファイルがありません"
+
+.PHONY: prod-backup-restore
+prod-backup-restore: ## 指定ファイルからDBをリストア（例: make prod-backup-restore FILE=backups/20240101_020000.sql.gz）
+	@test -n "$(FILE)" || { echo "エラー: FILE=<バックアップファイルパス> を指定してください"; exit 1; }
+	@test -f "$(FILE)" || { echo "エラー: ファイルが見つかりません: $(FILE)"; exit 1; }
+	@echo "⚠️  警告: $(FILE) からリストアします。現在のデータが上書きされます。続行しますか? [y/N]" && read ans && [ $${ans:-N} = y ]
+	@gunzip -c $(FILE) | $(PROD_COMPOSE) exec -T db psql -U $(BACKUP_POSTGRES_USER) $(BACKUP_POSTGRES_DB)
+	@echo "✅ リストアが完了しました"
+
+.PHONY: prod-backup-cron
+prod-backup-cron: ## cronにバックアップジョブを登録（デフォルト: 毎日2時）
+	@CRON_CMD="$(BACKUP_CRON_SCHEDULE) cd $$(pwd) && make prod-backup >> /var/log/backup.log 2>&1"; \
+	( crontab -l 2>/dev/null | grep -v "make prod-backup"; echo "$$CRON_CMD" ) | crontab -
+	@echo "✅ cronジョブを登録しました: $(BACKUP_CRON_SCHEDULE)"
+
+.PHONY: prod-backup-cron-remove
+prod-backup-cron-remove: ## cronからバックアップジョブを削除
+	@crontab -l 2>/dev/null | grep -v "make prod-backup" | crontab -
+	@echo "✅ cronジョブを削除しました"
+
+.PHONY: prod-backup-cron-status
+prod-backup-cron-status: ## cronジョブの状態と最新ログを表示
+	@echo "=== 登録済みcronジョブ ==="
+	@crontab -l 2>/dev/null | grep "make prod-backup" || echo "バックアップcronジョブは登録されていません"
+	@echo ""
+	@echo "=== 最新のcronログ (直近20行) ==="
+	@tail -n 20 /var/log/backup.log 2>/dev/null || echo "ログファイルがありません"

--- a/README.md
+++ b/README.md
@@ -585,6 +585,58 @@ docker compose -f compose.development.yaml --env-file .env.development exec app 
 
 ---
 
+## バックアップ運用
+
+### 即時バックアップ
+
+```bash
+make prod-backup
+# → backups/YYYYMMDD_HHMMSS.sql.gz に保存
+# → 7日以上前のバックアップを自動削除（デフォルト）
+```
+
+保持日数を変更する場合:
+
+```bash
+make prod-backup BACKUP_RETENTION_DAYS=14
+```
+
+### バックアップ一覧
+
+```bash
+make prod-backup-list
+```
+
+### リストア
+
+```bash
+make prod-backup-restore FILE=backups/20240101_020000.sql.gz
+```
+
+実行前に確認プロンプトが表示されます。
+
+### cronによる自動バックアップ
+
+```bash
+# 登録（デフォルト: 毎日2:00）
+make prod-backup-cron
+
+# スケジュール変更（例: 毎日3:30）
+make prod-backup-cron BACKUP_CRON_SCHEDULE="30 3 * * *"
+
+# 状態確認
+make prod-backup-cron-status
+
+# 削除
+make prod-backup-cron-remove
+```
+
+ログは `/var/log/backup.log` に記録されます。
+
+> **Note**: `backups/` ディレクトリは `.gitignore` に追加してください。
+
+---
+
 ## ライセンス
 
 このプロジェクトはMITライセンスの下で公開されています。


### PR DESCRIPTION
## 概要

issue#112 で提起された本番DBバックアップ課題を実装。
norn_os での実装・動作確認（本番VPS）を経てボイラープレートに反映。

## 変更内容

- `make prod-backup` — pg_dumpによる即時バックアップ（gzip圧縮、世代管理付き）
- `make prod-backup-list` — バックアップ一覧をサイズ付きで表示
- `make prod-backup-restore FILE=...` — 確認プロンプト付きリストア
- `make prod-backup-cron` — cronジョブ登録（デフォルト: 毎日2:00）
- `make prod-backup-cron-remove` — cronジョブ削除
- `make prod-backup-cron-status` — cron状態・ログ確認
- `README.md` にバックアップ運用手順を追記

## 設定変数

| 変数 | デフォルト | 説明 |
|---|---|---|
| `BACKUP_RETENTION_DAYS` | 7 | バックアップ保持日数 |
| `BACKUP_CRON_SCHEDULE` | `0 2 * * *` | cronスケジュール |

## 関連

- issue#112
- zomians/norn_os#401 （先行実装・動作確認済み）